### PR TITLE
Complete set operations for domainlike types

### DIFF
--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -700,7 +700,7 @@ end
         @testset "mixed intervals" begin
             d = (0..1) × (0.0..1)
             @test v[0.1,0.2] ∈ d
-            @test d isa EuclideanDomain{2} 
+            @test d isa EuclideanDomain{2}
         end
     end
     @testset "embedded" begin
@@ -719,14 +719,16 @@ end
 end
 
 @testset "Set operations" begin
-    d1 = UnitDisk()
-    d2 = (-.9..0.9)^2
-    d3 = (-.5 .. -.1) × (.5 .. 0.1)
-
-    @test isempty(d3)
-    @test convert(Domain{SVector{2,Float64}}, d3) isa Domain{SVector{2,Float64}}
-
     @testset "union" begin
+        d1 = UnitDisk()
+        d2 = (-.9..0.9)^2
+        d3 = (-.5 .. -.1) × (.5 .. 0.1)
+        d4 = (0.0..1.5)
+        d5 = [1.0,3.0]
+
+        @test isempty(d3)
+        @test convert(Domain{SVector{2,Float64}}, d3) isa Domain{SVector{2,Float64}}
+
         u1 = d1 ∪ d2
         u2 = u1 ∪ d3
 
@@ -748,6 +750,17 @@ end
         @test ũ2 == ũ2
         @test u1 == ũ2
 
+        # Don't create a union with two identical elements
+        @test (d1 ∪ d1) isa typeof(d1)
+
+        # union with non-Domain type that implements domain interface
+        u45 = UnionDomain(d4, d5)
+        @test u45 isa Domain{Float64}
+        @test 0.2 ∈ u45
+        @test 1.2 ∈ u45
+        @test -1.2 ∉ u45
+        @test convert(Domain{BigFloat}, u45) isa Domain{BigFloat}
+
         # ordering doesn't matter
         @test UnionDomain(d1,d2) == UnionDomain(d2,d1)
 
@@ -763,6 +776,9 @@ end
         d1 = UnitDisk()
         d2 = (-.4..0.4)^2
         d3 = (-.5 .. 0.5) × (-.1.. 0.1)
+        d4 = (0.0..1.5)
+        d5 = [1.0,3.0]
+
         # intersection of productdomains
         i1 = d2 & d3
         show(io,i1)
@@ -783,11 +799,19 @@ end
         @test y∉i3
         @test y∉i4
 
+        d45 = IntersectionDomain(d4, d5)
+        @test d45 isa Domain{Float64}
+        @test 1.0 ∈ d45
+        @test 1.1 ∉ d45
+        @test convert(Domain{BigFloat}, d45) isa Domain{BigFloat}
     end
 
     @testset "difference" begin
         d1 = UnitDisk()
         d2 = (-.5..0.5) × (-.1..0.1)
+        d3 = 0.0..3.0
+        d4 = [1.0, 2.5]
+
         # intersection of productdomains
         d = d1\d2
         show(io,d)
@@ -797,6 +821,13 @@ end
         y = SVector(0.,.25)
         @test x∈d
         @test x∈d
+
+        d34 = DifferenceDomain(d3, d4)
+        @test d34 isa Domain{Float64}
+        @test d34 isa DifferenceDomain
+        @test 0.99 ∈ d34
+        @test 1.0 ∉ d34
+        @test convert(Domain{BigFloat}, d34) isa Domain{BigFloat}
     end
 
     @testset "arithmetic" begin


### PR DESCRIPTION
This pull request implements changes to `IntersectionDomain` and `DifferenceDomain` so that they also support domain-like types, and adds some tests for this case.

The `union` function is only extended for actual `Domain` types. Domainlike types can only be grouped by explicitly invoking the `UnionDomain` constructor, because we can't hijack `union` with duck typing in this package.

I looked into making the domains in `UnionDomain` into a `Set`, but there is a tradeoff: the `Set` would preserve types only if all domains have the same type. Currently, since the `domains` field can be a tuple, it is at least possible to preserve all type information. The disadvantage is that a large union will be demanding for the compiler, presumably.

Todo: do performance tests on the constructor and, if necessary, make some special cases more efficient.