### PR TITLE
add known set operations for FixedIntervals

### DIFF
--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -128,6 +128,66 @@ similar_interval(d::Interval{L,R,T}, a, b) where {L,R,T} =
     Interval{L,R,float(T)}(a, b)
 
 
+#########################################
+# A few set operations with known result
+#########################################
+
+# We define an exhaustive list of combinations of the four fixed intervals
+# combined above in the routines 'intersect', 'union' and 'setdiff' where
+# the output is known explicitly.
+
+# Since fixed intervals are fully determined by their type,
+# the result of intersect, union or setdiff is always known for two
+# domains of the same type.
+intersect(d1::D, d2::D) where {D <: FixedInterval} = d1
+union(d1::D, d2::D) where {D <: FixedInterval} = d1
+setdiff(d1::D, d2::D) where {D <: FixedInterval} = EmptySpace{eltype(D)}()
+
+# [0,1] ∩ [-1,1] = [0,1]
+intersect(d1::UnitInterval{T}, d2::ChebyshevInterval{T}) where {T} = UnitInterval{T}()
+intersect(d1::ChebyshevInterval{T}, d2::UnitInterval{T}) where {T} = UnitInterval{T}()
+# [0,1] ∩ [0,∞) = [0,1]
+intersect(d1::UnitInterval{T}, d2::HalfLine{T}) where {T} = UnitInterval{T}()
+intersect(d1::HalfLine{T}, d2::UnitInterval{T}) where {T} = UnitInterval{T}()
+# [0,1] ∩ (-∞,0) = {}
+intersect(d1::UnitInterval{T}, d2::NegativeHalfLine{T}) where {T} = EmptySpace{T}()
+intersect(d1::NegativeHalfLine{T}, d2::UnitInterval{T}) where {T} = EmptySpace{T}()
+# [-1,1] ∩ [0,∞) = [0,1]
+intersect(d1::ChebyshevInterval{T}, d2::HalfLine{T}) where {T} = UnitInterval{T}()
+intersect(d1::HalfLine{T}, d2::ChebyshevInterval{T}) where {T} = UnitInterval{T}()
+# [0,∞) ∩ (-∞,0) = {}
+intersect(d1::HalfLine{T}, d2::NegativeHalfLine{T}) where {T} = EmptySpace{T}()
+intersect(d1::NegativeHalfLine{T}, d2::HalfLine{T}) where {T} = EmptySpace{T}()
+
+# [0,1] ∪ [-1,1] = [-1,1]
+union(d1::UnitInterval{T}, d2::ChebyshevInterval{T}) where {T} = ChebyshevInterval{T}()
+union(d1::ChebyshevInterval{T}, d2::UnitInterval{T}) where {T} = ChebyshevInterval{T}()
+# [0,1] ∪ [0,∞) = [0,∞)
+union(d1::UnitInterval{T}, d2::HalfLine{T}) where {T} = HalfLine{T}()
+union(d1::HalfLine{T}, d2::UnitInterval{T}) where {T} = HalfLine{T}()
+
+# (-∞,0) ∪ [0,∞) = (-∞,∞)
+# Note: T<:real to ensure that FullSpace{T} is not larger than intended.
+union(d1::NegativeHalfLine{T}, d2::HalfLine{T}) where {T<:Real} = FullSpace{T}()
+union(d1::HalfLine{T}, d2::NegativeHalfLine{T}) where {T<:Real} = FullSpace{T}()
+
+
+# [0,1] ∖ [-1,1] = {}
+setdiff(d1::UnitInterval{T}, d2::ChebyshevInterval{T}) where {T} = EmptySpace{T}()
+# [0,1] ∖ [0,∞) = {}
+setdiff(d1::UnitInterval{T}, d2::HalfLine{T}) where {T} = EmptySpace{T}()
+# [0,1] ∖ (-∞,0) = [0,1]
+setdiff(d1::UnitInterval{T}, d2::NegativeHalfLine{T}) where {T} = UnitInterval{T}()
+# [-1,1] ∖ (-∞,0) = [0,1]
+setdiff(d1::ChebyshevInterval{T}, d2::NegativeHalfLine{T}) where {T} = UnitInterval{T}()
+# [0,∞) ∖ (-∞,0) = [0,∞)
+setdiff(d1::HalfLine{T}, d2::NegativeHalfLine{T}) where {T} = HalfLine{T}()
+# (-∞,0) ∖ [0,1] = (-∞,0)
+setdiff(d1::NegativeHalfLine{T}, d2::UnitInterval{T}) where {T} = NegativeHalfLine{T}()
+# (-∞,0) ∖ [0,∞) = (-∞,0)
+setdiff(d1::NegativeHalfLine{T}, d2::HalfLine{T}) where {T} = NegativeHalfLine{T}()
+
+
 #################################
 # Conversions between intervals
 #################################

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -108,6 +108,10 @@ end
             @test minimum(d) == infimum(d) == leftendpoint(d)
             @test maximum(d) == supremum(d) == rightendpoint(d)
 
+            @test d ∩ d === d
+            @test d ∪ d === d
+            @test d \ d === EmptySpace{T}()
+
             @test isclosed(d)
             @test !DomainSets.isopen(d)
             @test iscompact(d)
@@ -128,6 +132,12 @@ end
             @test rightendpoint(d) == one(T)
             @test minimum(d) == infimum(d) == leftendpoint(d)
             @test maximum(d) == supremum(d) == rightendpoint(d)
+
+            @test d ∩ d === d
+            @test d ∪ d === d
+            @test d \ d === EmptySpace{T}()
+            @test d ∩ UnitInterval{T}() === UnitInterval{T}()
+            @test d ∪ UnitInterval{T}() === d
 
             @test isclosed(d)
             @test !DomainSets.isopen(d)
@@ -151,6 +161,10 @@ end
             @test supremum(d) == rightendpoint(d)
             @test_throws ArgumentError maximum(d)
 
+            @test d ∩ d === d
+            @test d ∪ d === d
+            @test d \ d == EmptySpace{T}()
+
             @test !isclosed(d)
             @test !DomainSets.isopen(d)
             @test !iscompact(d)
@@ -171,6 +185,11 @@ end
             @test supremum(d) == rightendpoint(d)
             @test_throws ArgumentError minimum(d)
             @test_throws ArgumentError maximum(d)
+
+            @test d ∩ d === d
+            @test d ∪ d === d
+            @test d \ d == EmptySpace{T}()
+            @test d ∪ HalfLine{T}() === FullSpace{T}()
 
             @test !isclosed(d)
             @test DomainSets.isopen(d)


### PR DESCRIPTION
Since is a `FixedInterval` is always completely determined by its type, there are several set operations that we know explicitly. I tried to think of all combinations and added them, mainly because in other code elsewhere I want the intersection of a `ChebyshevInterval` with itself to remain a `ChebyshevInterval`, and currently that is not the case (the generic code returns a generic closed interval `[-1,1]`).
