### PR TITLE
throw error for incompatible types in 'in' method

### DIFF
--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -51,7 +51,6 @@ euclideanspace(n::Val{N}) where {N} = euclideanspace(n, Float64)
 euclideanspace(::Val{N}, ::Type{T}) where {N,T} = FullSpace{SVector{N,T}}()
 
 indomain(x::T, d::FullSpace{T}) where {T} = true
-indomain(x::S, d::FullSpace{T}) where {T,S} = promotes_to(S,T) == Val{true}
 
 approx_indomain(x, d::FullSpace, tolerance) = in(x, d)
 

--- a/src/generic/derived_domain.jl
+++ b/src/generic/derived_domain.jl
@@ -19,4 +19,5 @@ superdomain(d::DerivedDomain) = d.superdomain
 "Return the eltype of the superdomain."
 supereltype(d::DerivedDomain) = eltype(superdomain(d))
 
-indomain(x, d::DerivedDomain) = in(x, superdomain(d))
+indomain(x, d::DerivedDomain) = indomain(x, superdomain(d))
+approx_indomain(x, d::DerivedDomain, tolerance) = approx_indomain(x, superdomain(d), tolerance)

--- a/src/generic/domain.jl
+++ b/src/generic/domain.jl
@@ -32,7 +32,7 @@ _in(x::T, d::Domain{T}) where {T} = indomain(x, d)
 
 function _in(x, d::Domain)
    T = promote_type(typeof(x), eltype(d))
-   T == Any && return false
+   T == Any && throw(InexactError(:convert, eltype(d), x))
    in(convert(T, x), convert(Domain{T}, d))
 end
 
@@ -59,7 +59,7 @@ approx_in(x::T, d::Domain{T}, tolerance = default_tolerance(d)) where {T} =
 
 function approx_in(x, d::Domain, tolerance = default_tolerance(d))
    T = promote_type(typeof(x), eltype(d))
-   T == Any && return false
+   T == Any && throw(InexactError(:convert, eltype(d), x))
    approx_in(convert(T, x), convert(Domain{T}, d), tolerance)
 end
 


### PR DESCRIPTION
The `in` method tries to promote the types of the point `x` and of the element type of a domain. It currently returns false if this promotion fails. The proposal is to throw an error instead, because comparing incompatible types is often not intended, and the change would catch more bugs (it was a bug that triggered this pull request).

The current version of DomainSets has this behaviour:
```julia
julia> using DomainSets

julia> 1 ∈ (0..1)^2
false
```

No error is thrown even though 1 clearly is not a point in the 2D plane. After the pull request this changes to:
```julia
julia> 1 ∈ (0..1)^2
ERROR: InexactError: convert(StaticArrays.SArray{Tuple{2},Int64,1,2}, 1)
```

This is an intrusive change, changing the semantics of `in`. However, I find that without it I explicitly have to check for the types of the elements myself in various places.

One could argue that `in` should return false when `x` does not have the right type. That is what `Set` in Base seems to do. But we are not consistently doing that anyway. For example:
```julia
julia> (1,2) ∈ 0..1.0
ERROR: MethodError: no method matching isless(::Float64, ::Tuple{Int64,Int64})
```
There are other examples: whenever the promotion of the domain to `Domain{promote_type(typeof(x),eltype(domain)}` fails, an error is thrown rather than returning false. These errors are helpful, because you immediately see that you are doing something possibly unintended at best, and simply wrong at worst.

