### PR TITLE
rename isopen/isclosed/iscompact

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-IntervalSets = "0.3, 0.4"
+IntervalSets = "0.5"
 StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12"
 julia = "1"

--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -84,7 +84,7 @@ export CartToPolarMap, PolarToCartMap
 export Domain, EuclideanDomain, VectorDomain,
     dimension,
     approx_in,
-    isopenset, isclosedset, iscompactset,
+    isopenset, isclosedset, iscompact,
     boundary, ∂,
     point_in_domain
 

--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -39,7 +39,7 @@ import Base: *, +, -, /, \, ^,
 # IntervalSets
 import IntervalSets: (..), endpoints, Domain, AbstractInterval, TypedEndpointsInterval,
                         leftendpoint, rightendpoint, isleftopen, isleftclosed,
-                        isrightopen, isrightclosed, isopen, isclosed,
+                        isrightopen, isrightclosed, isopenset, isclosedset,
                         infimum, supremum
 export ..
 
@@ -84,7 +84,7 @@ export CartToPolarMap, PolarToCartMap
 export Domain, EuclideanDomain, VectorDomain,
     dimension,
     approx_in,
-    isclosed, iscompact,
+    isopenset, isclosedset, iscompactset,
     boundary, ∂,
     point_in_domain
 

--- a/src/domains/ball.jl
+++ b/src/domains/ball.jl
@@ -20,9 +20,9 @@ const EuclideanHyperBall{N,T,C} = HyperBall{SVector{N,T},C}
 "A ball with vector elements of variable length."
 const VectorHyperBall{T,C} = HyperBall{Vector{T},C}
 
-isclosed(::HyperBall{T,:closed}) where {T} = true
-isclosed(::HyperBall{T,:open}) where {T} = false
-isopen(ball::HyperBall) = !isclosed(ball)
+isclosedset(::HyperBall{T,:closed}) where {T} = true
+isclosedset(::HyperBall{T,:open}) where {T} = false
+isopenset(ball::HyperBall) = !isclosedset(ball)
 
 indomain(x, ball::HyperBall) = norm(x) <= radius(ball)
 approx_indomain(x, ball::HyperBall, tolerance) = norm(x) <= radius(ball)+tolerance
@@ -31,7 +31,7 @@ approx_indomain(x, ball::HyperBall, tolerance) = norm(x) <= radius(ball)+toleran
 isempty(ball::HyperBall{T,:closed}) where {T} = false
 isempty(ball::HyperBall{T,:open}) where {T} = radius(ball) == 0
 
-==(d1::HyperBall, d2::HyperBall) = isclosed(d1)==isclosed(d2) &&
+==(d1::HyperBall, d2::HyperBall) = isclosedset(d1)==isclosedset(d2) &&
     radius(d1)==radius(d2) && dimension(d1)==dimension(d2)
 
 "The unit ball."
@@ -111,8 +111,8 @@ approx_indomain(x, sphere::HyperSphere, tolerance) =
 
 isempty(::HyperSphere) = false
 
-isclosed(::HyperSphere) = true
-isopen(::HyperSphere) = false
+isclosedset(::HyperSphere) = true
+isopenset(::HyperSphere) = false
 
 ==(d1::HyperSphere, d2::HyperSphere) =
     radius(d1)==radius(d2) && dimension(d1)==dimension(d2)

--- a/src/domains/point.jl
+++ b/src/domains/point.jl
@@ -23,8 +23,8 @@ isempty(::Point) = false
 
 approx_indomain(x, d::Point, tolerance) = norm(x-d.x) <= tolerance
 
-isopen(d::Point) = false
-isclosed(d::Point) = true
+isopenset(d::Point) = false
+isclosedset(d::Point) = true
 
 boundary(d::Point) = d
 

--- a/src/domains/simplex.jl
+++ b/src/domains/simplex.jl
@@ -5,10 +5,10 @@
 
 abstract type Simplex{T,C} <: Domain{T} end
 
-isclosed(::Simplex{T,:closed}) where {T} = true
-isclosed(::Simplex{T,:open}) where {T} = false
+isclosedset(::Simplex{T,:closed}) where {T} = true
+isclosedset(::Simplex{T,:open}) where {T} = false
 
-isopen(d::Simplex) = !isclosed(d)
+isopenset(d::Simplex) = !isclosedset(d)
 
 abstract type AbstractUnitSimplex{T,C} <: Simplex{T,C} end
 
@@ -23,7 +23,7 @@ approx_indomain(x, ::AbstractUnitSimplex, tolerance) = mapreduce( t-> t >= -tole
 isempty(::AbstractUnitSimplex) = false
 
 ==(d1::AbstractUnitSimplex, d2::AbstractUnitSimplex) =
-    isclosed(d1)==isclosed(d2) && dimension(d1)==dimension(d2)
+    isclosedset(d1)==isclosedset(d2) && dimension(d1)==dimension(d2)
 
 struct FixedUnitSimplex{T,C} <: AbstractUnitSimplex{T,C}
 end

--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -16,8 +16,8 @@ approx_indomain(x, d::EmptySpace, tolerance) = in(x, d)
 
 isempty(d::EmptySpace) = true
 
-isopen(d::EmptySpace) = true
-isclosed(d::EmptySpace) = true
+isopenset(d::EmptySpace) = true
+isclosedset(d::EmptySpace) = true
 
 boundary(d::EmptySpace) = d
 interior(d::EmptySpace) = d
@@ -66,8 +66,8 @@ point_in_domain(d::FullSpace) = zero(eltype(d))
 
 isempty(::FullSpace) = false
 
-isopen(d::FullSpace) = true
-isclosed(d::FullSpace) = true
+isopenset(d::FullSpace) = true
+isclosedset(d::FullSpace) = true
 
 boundary(d::FullSpace{T}) where {T} = EmptySpace{T}()
 interior(d::FullSpace) = d

--- a/src/generic/mapped_domain.jl
+++ b/src/generic/mapped_domain.jl
@@ -36,8 +36,8 @@ const MappedVectorDomain{D,T} = MappedDomain{D,Vector{T}}
 # TODO: check whether the map alters the dimension
 dimension(d::MappedVectorDomain) = dimension(source(d))
 
-# isopen(d::MappedDomain) = isopen(source(d))
-# isclosed(d::MappedDomain) = isclosed(source(d))
+# isopenset(d::MappedDomain) = isopenset(source(d))
+# isclosedset(d::MappedDomain) = isclosedset(source(d))
 #
 # TODO: we can't really define open and close in general this way.
 # We need more properties of the map to be able to conclude whether the mapped

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -49,8 +49,8 @@ else
 end
 
 isempty(d::ProductDomain) = any(isempty, elements(d))
-isclosed(d::ProductDomain) = all(isclosed, elements(d))
-isopen(d::ProductDomain) = all(isopen, elements(d))
+isclosedset(d::ProductDomain) = all(isclosed, elements(d))
+isopenset(d::ProductDomain) = all(isopen, elements(d))
 
 function show(io::IO, d::ProductDomain)
     L = numelements(d)

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -49,8 +49,8 @@ else
 end
 
 isempty(d::ProductDomain) = any(isempty, elements(d))
-isclosedset(d::ProductDomain) = all(isclosed, elements(d))
-isopenset(d::ProductDomain) = all(isopen, elements(d))
+isclosedset(d::ProductDomain) = all(isclosedset, elements(d))
+isopenset(d::ProductDomain) = all(isopenset, elements(d))
 
 function show(io::IO, d::ProductDomain)
     L = numelements(d)

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -522,7 +522,7 @@ end
         @test v[1.5,1.5] ∈ 1.2*D
         @test v[1.5,1.5] ∈ D*1.2
         @test !isempty(D)
-        # TODO: implement and test isclosed and isopen for mapped domains
+        # TODO: implement and test isclosedset and isopenset for mapped domains
 
         D = 2UnitDisk() + v[1.0,1.0]
         @test v[2.4, 2.4] ∈ D

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -30,8 +30,8 @@ end
         @test d1 ∪ d1 == d1
         @test boundary(d1) == d1
         @test dimension(d1) == 1
-        @test isclosed(d1)
-        @test DomainSets.isopen(d1)
+        @test isclosedset(d1)
+        @test DomainSets.isopenset(d1)
         d2 = 0..1
         @test d1 ∩ d2 == d1
         @test d1 ∪ d2 == d2
@@ -57,8 +57,8 @@ end
         @test d1 ∩ d1 == d1
         @test isempty(d1) == false
         @test boundary(d1) == EmptySpace{Float64}()
-        @test isclosed(d1)
-        @test DomainSets.isopen(d1)
+        @test isclosedset(d1)
+        @test DomainSets.isopenset(d1)
         @test dimension(d1) == 1
         d2 = 0..1
         @test d1 ∪ d2 == d1
@@ -86,8 +86,8 @@ end
         @test !approx_in(1.2, d, 0.1)
         @test !isempty(d)
         @test boundary(d) == d
-        @test isclosed(d)
-        @test !DomainSets.isopen(d)
+        @test isclosedset(d)
+        @test !DomainSets.isopenset(d)
         @test dimension(d) == 1
 
         @test d+1 == Domain(2.0)
@@ -118,8 +118,8 @@ end
             @test approx_in(1.1, d, 0.2)
             @test !approx_in(-0.2, d, 0.1)
             @test !approx_in(1.2, d, 0.1)
-            @test isclosed(d)
-            @test !DomainSets.isopen(d)
+            @test isclosedset(d)
+            @test !DomainSets.isopenset(d)
 
             @test iscompact(d)
             @test typeof(similar_interval(d, one(T), 2*one(T))) == typeof(d)
@@ -138,8 +138,8 @@ end
             @test d ∪ d === d
             @test d \ d === EmptySpace{T}()
 
-            @test isclosed(d)
-            @test !DomainSets.isopen(d)
+            @test isclosedset(d)
+            @test !DomainSets.isopenset(d)
             @test iscompact(d)
 
             @test convert(Domain, d) ≡ d
@@ -169,8 +169,8 @@ end
             @test unit ∪ d === d
             @test unit \ d === EmptySpace{T}()
 
-            @test isclosed(d)
-            @test !DomainSets.isopen(d)
+            @test isclosedset(d)
+            @test !DomainSets.isopenset(d)
             @test iscompact(d)
 
             @test convert(Domain, d) ≡ d
@@ -204,8 +204,8 @@ end
             @test unit ∪ d === d
             @test unit \ d === EmptySpace{T}()
 
-            @test !isclosed(d)
-            @test !DomainSets.isopen(d)
+            @test !isclosedset(d)
+            @test !DomainSets.isopenset(d)
             @test !iscompact(d)
             @test 1. ∈ d
             @test -1. ∉ d
@@ -244,8 +244,8 @@ end
             @test d \ unit === d
             @test d \ halfline === d
 
-            @test !isclosed(d)
-            @test DomainSets.isopen(d)
+            @test !isclosedset(d)
+            @test DomainSets.isopenset(d)
             @test !iscompact(d)
             @test -1. ∈ d
             @test 1. ∉ d
@@ -260,7 +260,7 @@ end
 
         @testset "OpenInterval{$T}" begin
             d = OpenInterval(0,1)
-            @test DomainSets.isopen(d)
+            @test DomainSets.isopenset(d)
 
             @test leftendpoint(d) ∈ ∂(d)
             @test rightendpoint(d) ∈ ∂(d)
@@ -501,8 +501,8 @@ end
         @test v[1.,1.] ∉ D
         @test approx_in(v[1.0,0.0+1e-5], D, 1e-4)
         @test !isempty(D)
-        @test isclosed(D)
-        @test !DomainSets.isopen(D)
+        @test isclosedset(D)
+        @test !DomainSets.isopenset(D)
         D2 = convert(Domain{SVector{2,BigFloat}}, D)
         @test eltype(D2) == SVector{2,BigFloat}
         @test boundary(D) == UnitCircle()
@@ -511,8 +511,8 @@ end
         D = EuclideanUnitBall{2,Float64,:open}()
         @test approx_in(v[1.0,0.0], D)
         @test v[0.2,0.2] ∈ D
-        @test !isclosed(D)
-        @test DomainSets.isopen(D)
+        @test !isclosedset(D)
+        @test DomainSets.isopenset(D)
         @test boundary(D) == UnitCircle()
 
         D = 2UnitDisk()
@@ -533,8 +533,8 @@ end
         @test v[1.,0.0,0.] ∈ B
         @test v[1.,0.1,0.] ∉ B
         @test !isempty(B)
-        @test isclosed(B)
-        @test !DomainSets.isopen(B)
+        @test isclosedset(B)
+        @test !DomainSets.isopenset(B)
         @test boundary(B) == UnitSphere()
 
         B = 2UnitBall()
@@ -557,8 +557,8 @@ end
         @test [0.0,0.1] ∉ C
         @test [0.0,1.1,0.2,0.1] ∉ C
         @test !isempty(C)
-        @test isclosed(C)
-        @test !DomainSets.isopen(C)
+        @test isclosedset(C)
+        @test !DomainSets.isopenset(C)
         @test boundary(C) == VectorUnitSphere(4)
         @test dimension(C) == 4
     end
@@ -580,8 +580,8 @@ end
         @test v[0.9, 0.9] ∈ D
         @test v[1.1, 1.1] ∉ D
         @test !isempty(D)
-        @test isclosed(D)
-        @test !DomainSets.isopen(D)
+        @test isclosedset(D)
+        @test !DomainSets.isopenset(D)
 
         @test approx_in(v[-0.1,-0.1], D, 0.1)
         @test !approx_in(v[-0.1,-0.1], D, 0.09)
@@ -599,8 +599,8 @@ end
         @test approx_in(v[1.,0.], C)
         @test !approx_in(v[1.,1.], C)
         @test !isempty(C)
-        @test isclosed(C)
-        @test !DomainSets.isopen(C)
+        @test isclosedset(C)
+        @test !DomainSets.isopenset(C)
         p = parameterization(C)
         x = applymap(p, 1/2)
         @test DomainSets.domain(p) == Interval{:closed,:open,Float64}(0, 1)
@@ -718,14 +718,14 @@ end
 
         @test convert(Domain{SVector{2,BigFloat}}, d) == UnitSimplex{2,BigFloat}()
 
-        @test isclosed(d)
-        @test !DomainSets.isopen(d)
+        @test isclosedset(d)
+        @test !DomainSets.isopenset(d)
         @test point_in_domain(d) ∈ d
 
         # open/closed
         d2 = EuclideanUnitSimplex{2,Float64,:open}()
-        @test !isclosed(d2)
-        @test DomainSets.isopen(d2)
+        @test !isclosedset(d2)
+        @test DomainSets.isopenset(d2)
         @test v[0.3,0.1] ∈ d2
 
         d3 = EuclideanUnitSimplex{3,BigFloat}()


### PR DESCRIPTION
Reflecting the rename in IntervalSets version 0.5, we rename isopen/isclosed to isopenset/isclosedset. It seems to make sense to rename iscompact to iscompact set as well.