### PR TITLE
Change compat entry for CompositeTypes.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CompositeTypes = "0.1.1"
+CompositeTypes = "0.1"
 IntervalSets = "0.5"
 StaticArrays = "0.12.2, 1"
 julia = "1.3"


### PR DESCRIPTION
This PR changes the compat entry for [`CompositeTypes.jl`](https://github.com/JuliaApproximation/CompositeTypes.jl) package. See also: [issue3](https://github.com/JuliaApproximation/CompositeTypes.jl/issues/3).