### PR TITLE
Move Test to [extras]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,15 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CompositeTypes = "0.1.2"
 IntervalSets = "0.5"
 StaticArrays = "0.12.2, 1"
 julia = "1.3"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -142,6 +142,7 @@ export EmptySpace, FullSpace,
 export AbstractInterval, Interval, UnitInterval, ChebyshevInterval,
     OpenInterval, ClosedInterval,
     leftendpoint, rightendpoint, isleftopen, isrightopen,
+    cardinality,
     HalfLine, NegativeHalfLine
 # from domains/simplex.jl
 export UnitSimplex,

--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -142,7 +142,6 @@ export EmptySpace, FullSpace,
 export AbstractInterval, Interval, UnitInterval, ChebyshevInterval,
     OpenInterval, ClosedInterval,
     leftendpoint, rightendpoint, isleftopen, isrightopen,
-    cardinality,
     HalfLine, NegativeHalfLine
 # from domains/simplex.jl
 export UnitSimplex,


### PR DESCRIPTION
Hi, I noticed `Test` is currently included in the `deps` block of Project.toml. This requires loading Test in order to use the package, which seems like unnecessary overhead. This little PR adds an `extras` section and moves `Test` there.

I also noticed `cardinality` is exported but undefined, so the PR removes this.