### PR TITLE
Fix ℝ == ℝ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1.5'
-          - '^1.6.0-0'
+          - '1'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DomainSets"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 CompositeTypes = "b152e2b5-7a66-4b01-a709-34e65c35f657"

--- a/src/domains/numbers.jl
+++ b/src/domains/numbers.jl
@@ -5,6 +5,7 @@ end
 
 in(x, d::NaturalNumbers) = isinteger(x) && (x >= 0)
 in(x::AbstractArray, d::NaturalNumbers) = false
+==(::NaturalNumbers, ::NaturalNumbers) = true
 
 approx_in(x::Real, d::NaturalNumbers, tol) =
     (abs(x-round(x)) < tol) && (round(Int, x) ∈ d)
@@ -16,6 +17,7 @@ end
 
 in(x, d::Integers) = isinteger(x)
 in(x::AbstractArray, d::Integers) = false
+==(::Integers, ::Integers) = true
 
 approx_in(x::Real, d::Integers, tol) =
     (abs(x-round(x)) < tol) && (round(Int, x) ∈ d)
@@ -30,7 +32,7 @@ in(x::Number, d::RealNumbers) = isreal(x)
 in(x::AbstractArray, d::RealNumbers) = false
 
 approx_in(x::Complex, d::RealNumbers, tol) = (imag(x) < tol) && (real(x) ∈ d)
-
+==(::RealNumbers, ::RealNumbers) = true
 
 "The set of all rationals."
 struct Rationals <: Domain{Rational{Int}}
@@ -38,7 +40,7 @@ end
 
 in(x, d::Rationals) = x ∈ Integers()
 in(x::Rational, d::Rationals) = true
-
+==(::Rationals, ::Rationals) = true
 
 "The set of all complex numbers whose real and imaginary parts are real numbers."
 struct ComplexNumbers <: Domain{Complex{Float64}}
@@ -48,6 +50,7 @@ in(x::Complex{T}, d::ComplexNumbers) where {T} =
     isreal(real(x)) && isreal(imag(x))
 in(x::Complex{T}, d::ComplexNumbers) where {T<:Real} = true
 in(x, d::ComplexNumbers) = x ∈ RealNumbers()
+==(::ComplexNumbers, ::ComplexNumbers) = true
 
 
 "The set of natural numbers."

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -146,6 +146,7 @@ end
         @test approx_in(1.01, ℕ, 0.05)
         @test !approx_in(1.01, ℕ, 0.001)
         @test !approx_in(-1.01, ℕ, 0.05)
+        @test ℕ == ℕ
         # integers
         @test 2 ∈ ℤ
         @test 0 ∈ ℤ
@@ -160,6 +161,7 @@ end
         @test approx_in(1.01, ℤ, 0.05)
         @test !approx_in(1.01, ℤ, 0.001)
         @test approx_in(-1.01, ℤ, 0.05)
+        @test ℤ == ℤ
         # rationals
         @test 2 ∈ ℚ
         @test 0 ∈ ℚ
@@ -171,6 +173,7 @@ end
         @test 4//2 ∈ ℚ
         @test (-4)//2 ∈ ℚ
         @test 5//2 ∈ ℚ
+        @test ℚ == ℚ
         # real numbers
         @test 2 ∈ ℝ
         @test 0 ∈ ℝ
@@ -188,6 +191,7 @@ end
         @test [1,2,3,4] ∈ ℝ4
         @test approx_in(1.0+0.01im, ℝ, 0.05)
         @test !approx_in(1.0+0.01im, ℝ, 0.005)
+        @test ℝ == ℝ
         # complex numbers
         @test 2 ∈ ℂ
         @test 0 ∈ ℂ
@@ -200,6 +204,7 @@ end
         @test 4//2 ∈ ℂ
         @test (-4)//2 ∈ ℂ
         @test 5//2 ∈ ℂ
+        @test ℂ == ℂ
     end
 
     @testset "point" begin


### PR DESCRIPTION
Fixes the following:
```julia
julia> ℝ == ℝ
ERROR: StackOverflowError:
Stacktrace:
     [1] simplifies(d::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:54
     [2] isequal1(d1::RealNumbers, d2::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:120
     [3] ==(d1::RealNumbers, d2::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:118
     [4] isdifferentfrom(d1::RealNumbers, d2::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:19
     [5] hascanonicaldomain(ctype::DomainSets.Equal, d::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:40
--- the last 5 lines are repeated 15995 more times ---
 [79981] simplifies(d::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:54
 [79982] isequal1(d1::RealNumbers, d2::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:120
 [79983] ==(d1::RealNumbers, d2::RealNumbers)
       @ DomainSets ~/Projects/DomainSets.jl/src/generic/canonical.jl:118
```

Probably a better fix is needed, e.g., by implementing `canonicaldomain`, but I don't quite understand what should be done.