### PR TITLE
improve 'hascanonicaldomain' function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DomainSets"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 CompositeTypes = "b152e2b5-7a66-4b01-a709-34e65c35f657"

--- a/src/applications/coordinates.jl
+++ b/src/applications/coordinates.jl
@@ -2,9 +2,7 @@
 "A `DomainPoint` is a point which is an element of a domain by construction."
 abstract type DomainPoint{T} end
 
-in(x::DomainPoint, d::Domain) = domain(x) == d || in(point(x), d)
-
-convert(::Type{T}, x::DomainPoint) where {T} = convert(T, point(x))
+in(p::DomainPoint, d::Domain) = domain(p) == d || in(point(p), d)
 
 
 ## Points on a sphere
@@ -13,7 +11,7 @@ convert(::Type{T}, x::DomainPoint) where {T} = convert(T, point(x))
 abstract type SpherePoint{T} <: DomainPoint{T} end
 
 domain(p::SpherePoint{T}) where {T<:StaticTypes} = UnitSphere{T}()
-domain(p::SpherePoint{T}) where {T<:AbstractVector} = UnitSphere{eltype(T)}(length(point(x)))
+domain(p::SpherePoint{T}) where {T<:AbstractVector} = UnitSphere{T}(length(point(p)))
 
 "A point on the unit sphere represented by a standard Euclidean vector."
 struct EuclideanSpherePoint{T} <: SpherePoint{T}

--- a/src/generic/lazy.jl
+++ b/src/generic/lazy.jl
@@ -106,7 +106,12 @@ abstract type DerivedDomain{T} <: SimpleLazyDomain{T} end
 
 isempty(d::DerivedDomain) = isempty(superdomain(d))
 
-canonicaldomain(d::DerivedDomain) = superdomain(d)
+# We assume the derived domain and the superdomain are equal
+canonicaldomain(d::DerivedDomain) = canonicaldomain(superdomain(d))
+canonicaldomain(::Equal, d::DerivedDomain) = canonicaldomain(Equal(), superdomain(d))
+canonicaldomain(::Isomorphic, d::DerivedDomain) = canonicaldomain(Isomorphic(), superdomain(d))
+canonicaldomain(::Parameterization, d::DerivedDomain) = canonicaldomain(Parameterization(), superdomain(d))
+
 boundingbox(d::DerivedDomain) = boundingbox(superdomain(d))
 interior(d::DerivedDomain) = interior(superdomain(d))
 closure(d::DerivedDomain) = closure(superdomain(d))

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -95,18 +95,20 @@ cross(x::Domain...) = productdomain(x...)
 
 similardomain(d::ProductDomain, ::Type{T}) where {T} = ProductDomain{T}(components(d))
 
-canonicaldomain(d::ProductDomain) = ProductDomain(map(canonicaldomain, components(d)))
+canonicaldomain(d::ProductDomain) = any(map(hascanonicaldomain, factors(d))) ?
+	ProductDomain(map(canonicaldomain, components(d))) : d
 
 mapto_canonical(d::ProductDomain) = ProductMap(map(mapto_canonical, components(d)))
 mapfrom_canonical(d::ProductDomain) = ProductMap(map(mapfrom_canonical, components(d)))
 
 for CTYPE in (Parameterization, Equal)
 	@eval canonicaldomain(ctype::$CTYPE, d::ProductDomain) =
-		ProductDomain(canonicaldomain.(Ref(ctype), components(d)))
+		any(hascanonicaldomain.(Ref(ctype), factors(d))) ?
+			ProductDomain(canonicaldomain.(Ref(ctype), factors(d))) : d
 	@eval mapto_canonical(ctype::$CTYPE, d::ProductDomain) =
-		ProductMap(mapto_canonical.(Ref(ctype), components(d)))
+		ProductMap(mapto_canonical.(Ref(ctype), factors(d)))
 	@eval mapfrom_canonical(ctype::$CTYPE, d::ProductDomain) =
-		ProductMap(mapfrom_canonical.(Ref(ctype), components(d)))
+		ProductMap(mapfrom_canonical.(Ref(ctype), factors(d)))
 end
 
 

--- a/test/test_generic_domain.jl
+++ b/test/test_generic_domain.jl
@@ -30,16 +30,22 @@ function test_generic_domain(d::Domain)
         end
     end
     @test canonicaldomain(DomainSets.Equal(), d) == d
-    if canonicaldomain(d) == d
-        @test mapto_canonical(d) == IdentityMap{eltype(d)}(dimension(d))
-        @test mapfrom_canonical(d) == IdentityMap{eltype(d)}(dimension(d))
-    else
+    if hascanonicaldomain(d)
         cd = canonicaldomain(d)
         @test mapfrom_canonical(d) == mapto(cd, d)
         @test mapto_canonical(d) == mapto(d, cd)
         x1 = point_in_domain(cd)
         @test mapfrom_canonical(d, x1) ∈ d
         @test mapto_canonical(d, x) ∈ cd
+    else
+        @test mapto_canonical(d) == IdentityMap{eltype(d)}(dimension(d))
+        @test mapfrom_canonical(d) == IdentityMap{eltype(d)}(dimension(d))
+    end
+    if hasparameterization(d)
+        par = parameterdomain(d)
+        @test mapfrom_parameterdomain(d) == mapto(par, d)
+        xp = point_in_domain(par)
+        @test approx_in(mapfrom_parameterdomain(d, xp), d)
     end
     if iscomposite(d)
         @test ncomponents(d) == length(components(d))

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -932,7 +932,7 @@ end
         @test String(take!(io)) == "UnitCircle()"
     end
 
-    @testset "custom named ball" begin
+    @testset "wrapped domains" begin
         B = NamedBall()
         @test SA[1.4, 1.4] ∈ B
         @test SA[1.5, 1.5] ∉ B
@@ -940,6 +940,23 @@ end
         @test SA[1.5,1.5] ∈ 1.2 * B
         @test SA[1.5,1.5] ∈ B * 1.2
         @test eltype(B) == eltype(2UnitDisk())
+
+        @test hascanonicaldomain(B)
+        @test canonicaldomain(B) == UnitDisk()
+        @test DomainSets.simplifies(B)
+        @test canonicaldomain(DomainSets.Equal(), B) === superdomain(B)
+        @test B == superdomain(B)
+
+        @test Domain([1,2,3]) isa DomainSets.WrappedDomain{Int,Vector{Int}}
+        @test Domain([1,2,3]) == Domain([1.0,2.0,3.0])
+        @test canonicaldomain(Domain([1,2,3])) == [1,2,3]
+
+        d = DomainSets.ExampleNamedDomain(UnitBall())
+        @test superdomain(d) == UnitBall()
+        @test hascanonicaldomain(d)
+        @test DomainSets.simplifies(d)
+        @test canonicaldomain(DomainSets.Equal(), d) === superdomain(d)
+        @test d == superdomain(d)
     end
 
     @testset "complex unit circle/disk" begin

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -957,6 +957,7 @@ end
         @test DomainSets.simplifies(d)
         @test canonicaldomain(DomainSets.Equal(), d) === superdomain(d)
         @test d == superdomain(d)
+        @test canonicaldomain(DomainSets.Isomorphic(), d) === superdomain(d)
     end
 
     @testset "complex unit circle/disk" begin
@@ -1145,6 +1146,25 @@ end
         @test dimension(D4) == 4
         cheb = ChebyshevInterval()
         @test boundingbox(D4) == ProductDomain([cheb, cheb, cheb, cheb])
+
+        ## sphere points
+        x_sphere = [0.1,0.2,1-(0.1)^2-(0.4)^2]
+        p1 = DomainSets.EuclideanSpherePoint(x_sphere)
+        @test DomainSets.domain(p1) == UnitSphere(3)
+        @test DomainSets.point(p1) == x_sphere
+        @test p1 ∈ UnitSphere()
+        @test p1 ∈ UnitSphere(3)
+        @test p1 ∈ DomainSets.domain(p1)
+
+        p2 = DomainSets.EuclideanSpherePoint(SVector{3}(x_sphere))
+        @test DomainSets.domain(p2) === UnitSphere()
+        @test DomainSets.point(p2) == x_sphere
+        @test p2 ∈ UnitSphere()
+
+        p3 = DomainSets.SphericalCoordinate(0.4, 0.5)
+        @test DomainSets.domain(p3) === UnitSphere()
+        @test p3 ∈ UnitSphere()
+        @test approx_in(DomainSets.point(p3), UnitSphere())
     end
 
     @testset "derived types" begin


### PR DESCRIPTION
There was a possible StackOverflowError when comparing equality of domains using its generic fallback, because it called `==` again. In this PR, the fallback is kept for the time being, but the circular path is removed.