### PR TITLE
Don't export factors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DomainSets"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 CompositeTypes = "b152e2b5-7a66-4b01-a709-34e65c35f657"

--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -77,8 +77,7 @@ export AbstractMap, Map, TypedMap,
 # from maps/composite.jl
 export ComposedMap, composedmap, ∘
 # from maps/product.jl
-export ProductMap, productmap,
-    nfactors, factors, factor
+export ProductMap, productmap
 # from maps/basic.jl
 export IdentityMap,
     StaticIdentityMap, VectorIdentityMap,

--- a/test/test_generic_domain.jl
+++ b/test/test_generic_domain.jl
@@ -1,3 +1,5 @@
+import DomainSets: factors, nfactors, factor
+
 
 widen_eltype(::Type{T}) where {T<:Number} = widen(T)
 widen_eltype(::Type{SVector{N,T}}) where {N,T<:Number} = SVector{N,widen(T)}


### PR DESCRIPTION
Adding new exports is a breaking change (and conflicts with ApproxFun) so should have waited to v0.6. 