### PR TITLE
`atol` and `rtol` in `isapprox`

### DIFF
--- a/src/domains/interval.jl
+++ b/src/domains/interval.jl
@@ -48,10 +48,14 @@ function point_in_domain(d::AbstractInterval{T}) where {T<:Integer}
     end
 end
 
+# TODO: type-piracy, should be removed in the next breaking release
+function isapprox(d1::AbstractInterval, d2::AbstractInterval;
+        atol=default_tolerance(d1),
+        rtol=Base.rtoldefault(eltype(d1), eltype(d2), atol))
 
-isapprox(d1::AbstractInterval, d2::AbstractInterval) =
-    isapprox(leftendpoint(d1), leftendpoint(d2); atol=default_tolerance(d1)) &&
-    isapprox(rightendpoint(d1), rightendpoint(d2); atol=default_tolerance(d1))
+    isapprox(leftendpoint(d1), leftendpoint(d2); atol, rtol) &&
+    isapprox(rightendpoint(d1), rightendpoint(d2); atol, rtol)
+end
 
 
 boundary(d::AbstractInterval) = Point(leftendpoint(d)) ∪ Point(rightendpoint(d))

--- a/test/test_domain_interval.jl
+++ b/test/test_domain_interval.jl
@@ -213,7 +213,7 @@ function test_intervals()
 
         @test (0..1) ≈ (1e-16..1)
         @test (-1..0) ≈ (-1..1e-16)
-        @test isapprox(HalfLine(), 0..Inf)
+        @test isapprox(HalfLine(), 0..Inf, atol=100eps())
     end
 
     @testset "mapping between intervals" begin


### PR DESCRIPTION
This adds `atol` and `rtol` parameters to the `isapprox` defined here. This method is committing type-piracy here (and perhaps harms pre-compilation, as it is overwriting the other method), so perhaps this should be removed in a future breaking version. The breakage comes from the fact that the `isapprox` defined in `IntervalSets` throws an error when comparing closed and open intervals, whereas this version doesn't.