### PR TITLE
reduce dependency on StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,19 +7,21 @@ CompositeTypes = "b152e2b5-7a66-4b01-a709-34e65c35f657"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CompositeTypes = "0.1.2"
 IntervalSets = "0.7.4"
 StaticArrays = "0.12.2, 1"
+StaticArraysCore = "1.0"
 StableRNGs = "1"
 julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
 [targets]
-test = ["Test", "StableRNGs"]
+test = ["Test", "StableRNGs", "StaticArrays"]

--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -1,10 +1,12 @@
 module DomainSets
 
-using StaticArrays
 using LinearAlgebra, Statistics
 import LinearAlgebra: cross, ×, pinv
 import Random
 using Random: AbstractRNG
+
+using StaticArraysCore
+using StaticArraysCore: StaticVector
 
 using IntervalSets
 using CompositeTypes, CompositeTypes.Display, CompositeTypes.Indexing


### PR DESCRIPTION
This PR demonstrates that we could have `StaticArraysCore` as a dependency rather than `StaticArrays`.

I'm not sure I like it, but it does reduce load time by more than 50%. In any case this is a breaking change, because one would have to load `StaticArrays` in addition to `DomainSets` in order to do anything in more than one dimension.