### PR TITLE
relax types for canonical domains

### DIFF
--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -44,8 +44,8 @@ map_domain(map::Map{T}, d::EmptySpace{T}) where {T} = d
 mapped_domain(map::Map, d::EmptySpace) = EmptySpace{codomaintype(map)}()
 
 ==(d1::EmptySpace, d2::EmptySpace) = true
-isequal1(d1::EmptySpace, d2) = isempty(d2)
-isequal2(d1, d2::EmptySpace) = isempty(d1)
+isequaldomain1(d1::EmptySpace, d2) = isempty(d2)
+isequaldomain2(d1, d2::EmptySpace) = isempty(d1)
 hash(d::EmptySpace, h::UInt) = hash("EmptySpace", h)
 
 
@@ -105,8 +105,8 @@ issubset2(d1, d2::FullSpace) = true
 map_domain(m::AbstractAffineMap{T}, d::FullSpace{T}) where {T} = d
 
 ==(d1::FullSpace, d2::FullSpace) = true
-isequal1(d1::FullSpace, d2) = isfullspace(d2)
-isequal2(d1, d2::FullSpace) = isfullspace(d1)
+isequaldomain1(d1::FullSpace, d2) = isfullspace(d2)
+isequaldomain2(d1, d2::FullSpace) = isfullspace(d1)
 hash(d::FullSpace, h::UInt) = hash("FullSpace", h)
 
 

--- a/src/generic/canonical.jl
+++ b/src/generic/canonical.jl
@@ -78,18 +78,18 @@ mapto_canonical(ctype::Parameterization, d) = leftinverse(mapfrom_canonical(ctyp
 
 # We define some convenience functions:
 "Return a parameter domain which supports a `parameterization`."
-parameterdomain(d::Domain) = canonicaldomain(Parameterization(), d)
+parameterdomain(d) = canonicaldomain(Parameterization(), d)
 
 "Return a parameterization of the given domain."
-parameterization(d::Domain) = mapfrom_canonical(Parameterization(), d)
+parameterization(d) = mapfrom_canonical(Parameterization(), d)
 
 "Does the domain have a parameterization?"
 hasparameterization(d) = hascanonicaldomain(Parameterization(), d)
 
-mapfrom_parameterdomain(d::Domain) = mapfrom_canonical(Parameterization(), d)
-mapto_parameterdomain(d::Domain) = mapto_canonical(Parameterization(), d)
-mapfrom_parameterdomain(d::Domain, x) = mapfrom_canonical(Parameterization(), d, x)
-mapto_parameterdomain(d::Domain, x) = mapto_canonical(Parameterization(), d, x)
+mapfrom_parameterdomain(d) = mapfrom_canonical(Parameterization(), d)
+mapto_parameterdomain(d) = mapto_canonical(Parameterization(), d)
+mapfrom_parameterdomain(d, x) = mapfrom_canonical(Parameterization(), d, x)
+mapto_parameterdomain(d, x) = mapto_canonical(Parameterization(), d, x)
 
 
 "Return a map from domain `d1` to domain `d2`."
@@ -109,13 +109,16 @@ no_known_mapto(d1, d2) = d1 == d2 ? identitymap(d1) : error("No map known betwee
 
 ## Equality for domains
 
+@deprecate isequal1(d1,d2) isequaldomain1(d1,d2)
+@deprecate isequal2(d1,d2) isequaldomain2(d1,d2)
+
 ## Note: here we generically define the equality of Domains, using the framework
 # of canonical domains above. It has the benefit of automatically recognizing
 # equality between some domains, but a side-effect is that the default
 # (implicitly defined) equality for a concrete domain type is overruled.
 # To be safe, concrete domains should specialize `==`.
-==(d1::Domain, d2::Domain) = isequal1(d1, d2)
+==(d1::Domain, d2::Domain) = isequaldomain1(d1, d2)
 # simplify the first argument
-isequal1(d1, d2) = simplifies(d1) ? simplify(d1)==d2 : isequal2(d1, d2)
+isequaldomain1(d1, d2) = simplifies(d1) ? simplify(d1)==d2 : isequaldomain2(d1, d2)
 # simplify the second argument
-isequal2(d1, d2) = simplifies(d2) ? d1==simplify(d2) : d1===d2
+isequaldomain2(d1, d2) = simplifies(d2) ? d1==simplify(d2) : d1===d2

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -95,8 +95,8 @@ include("test_domain_simplex.jl")
         @test closure(d1) == d1
         @test dimension(d1) == 1
         @test boundingbox(d1) == d1
-        @test DomainSets.isequal1(d1, d1)
-        @test DomainSets.isequal2(d1, d1)
+        @test DomainSets.isequaldomain1(d1, d1)
+        @test DomainSets.isequaldomain2(d1, d1)
         d2 = 0..1
         @test d1 ∪ d2 == d1
         @test d1 ∩ d2 == d2


### PR DESCRIPTION
This PR removes some unnecessary `::Domain` qualifications in the code for canonical domains.

That makes it more flexible to work with domains as an interface. Here is an example. The packages [Meshes.jl](https://github.com/JuliaGeometry/Meshes.jl/blob/master/src/primitives/sphere.jl) also defines a sphere. We declare the canonical domain of that sphere to be a unit ball from DomainSets. That enables one to compute the map from one to the other, regardless of their types:
```julia
julia> using DomainSets, Meshes, LinearAlgebra

julia> DomainSets.canonicaldomain(d::Meshes.Sphere{N,T}) where {N,T} = DomainSets.EuclideanUnitBall{N,T}()

julia> DomainSets.mapfrom_canonical(d::Meshes.Sphere) = AffineMap(Meshes.radius(d), Meshes.center(d).coords)

julia> s = Meshes.Sphere(Meshes.Point(0.2, 0.5), 1.3)
Meshes.Sphere{2, Float64}(Point(0.2, 0.5), 1.3)

julia> d = DomainSets.Ball(5, [0.1, -0.3])
Ball(5.0, [0.1, -0.3])

julia> m = mapto(s, d)
x -> 3.84615 * x + v

v = 2-element SVector{2, Float64} with indices SOneTo(2):
 -0.669231
 -2.22308

julia> norm(m(Meshes.center(s).coords) - DomainSets.center(d))
2.1677797545656835e-16
```