### PR TITLE
conditional generators

### DIFF
--- a/src/DomainSets.jl
+++ b/src/DomainSets.jl
@@ -212,6 +212,8 @@ include("domains/cube.jl")
 include("domains/indicator.jl")
 include("domains/boundingbox.jl")
 
+include("generic/generator.jl")
+
 include("applications/coordinates.jl")
 include("applications/random.jl")
 include("applications/rotation.jl")

--- a/src/domains/indicator.jl
+++ b/src/domains/indicator.jl
@@ -50,8 +50,13 @@ struct BoundedIndicatorFunction{F,D,T} <: AbstractIndicatorFunction{T}
     domain  ::  D
 end
 
-BoundedIndicatorFunction(f::F, domain::D) where {F,T,D<:Domain{T}} =
-    BoundedIndicatorFunction{F,D,T}(f, domain)
+BoundedIndicatorFunction(f, domain::Domain{T}) where {T} =
+    BoundedIndicatorFunction{typeof(f),typeof(domain),T}(f, domain)
+
+function BoundedIndicatorFunction(f, domain)
+    T = eltype(domain)
+    BoundedIndicatorFunction{typeof(f),typeof(domain),T}(f, domain)
+end
 
 indicatorfunction(d::BoundedIndicatorFunction) = d.f
 
@@ -66,17 +71,6 @@ hash(d::BoundedIndicatorFunction, h::UInt) =
 
 similardomain(d::BoundedIndicatorFunction, ::Type{T}) where {T} =
     BoundedIndicatorFunction(d.f, convert(Domain{T}, d.domain))
-
-Domain(gen::Base.Generator) = generator_domain(gen)
-
-generator_domain(gen::Base.Generator{<:Domain}) = BoundedIndicatorFunction(gen.f, gen.iter)
-generator_domain(gen::Base.Generator{<:Base.Iterators.ProductIterator}) =
-    productgenerator_domain(gen, gen.iter.iterators)
-
-function productgenerator_domain(gen, domains::Tuple{Vararg{Domain}})
-    domain = TupleProductDomain(gen.iter.iterators)
-    BoundedIndicatorFunction(gen.f, domain)
-end
 
 boundingbox(d::BoundedIndicatorFunction) = boundingbox(boundingdomain(d))
 

--- a/src/generic/generator.jl
+++ b/src/generic/generator.jl
@@ -1,0 +1,25 @@
+## Creating a domain from a generator
+
+Domain(gen::Base.Generator) = generator_domain(gen)
+
+generator_domain(gen::Base.Generator) = generator_domain(gen.f, gen.iter)
+
+# Example: Domain(x for x in 0..1)
+generator_domain(f::typeof(identity), iter::Domain) = iter
+# Example: Domain(x>1 for x in 0..2)
+generator_domain(f, iter::Domain) = BoundedIndicatorFunction(f, iter)
+
+# Example: Domain(x for x in 0..2 if x > 1)
+generator_domain(f::typeof(identity), iter::Base.Iterators.Filter) =
+    generator_domain(iter.flt, iter.itr)
+# Example: Domain(x>1 for x in 0..2 if x < 1.5)
+generator_domain(f, iter::Base.Iterators.Filter) =
+    generator_domain(t -> f(t) && iter.flt(t), iter.itr)
+# Example: Domain(x*y>0 for (x,y) in UnitDisk())
+generator_domain(f, iter::Base.Iterators.ProductIterator) =
+    generator_productdomain(f, iter.iterators)
+
+function generator_productdomain(f, iterators)
+    domain = TupleProductDomain(iterators)
+    BoundedIndicatorFunction(f, domain)
+end


### PR DESCRIPTION
It's fun to create domains with generator syntax, but we've been doing it wrong. Currently, we have
```julia
julia> Domain(x > 0 for x in -1..1)
indicator function bounded by: -1..1
```
This domain corresponds to the half-open interval `(0,1]` (although the code does not realize that), based on the boolean-valued indicator function `x -> x>0`.

In hindsight, that was not the right call. An indicator function is best specified as a conditional clause:
```julia
julia> Domain(x for x in -1..1 if x > 0)
indicator function bounded by: -1..1
```
This PR adds support for the latter.

In the future, perhaps we can use the generator syntax to create mapped domains, i.e. `Domain(2x for x in -1..1)` would correspond to `[-2,2]`. But right now the syntax is taken, so that would be a breaking change.

For now, I've just added if clauses to generators.