### PR TITLE
enable broadcast with notin

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -50,14 +50,22 @@ broadcasted(::DomainSetStyle, fun::Function, d::Domain{T}) where {T} =
 # has particular structure. A common case would be a raster of points,
 # for plotting purposes.
 # This call can be avoided by typing in.(A, Ref(d)) instead.
-broadcasted(::DomainSetStyle, ::typeof(in), A, d::Domain) = broadcast_in(A, d)
-broadcasted(::DomainSetStyle, ::typeof(approx_in), A, d::Domain, tol) = broadcast_approx_in(A, d, tol)
+broadcasted(::DomainSetStyle, ::typeof(in), A, d::Domain) = vectorized_in(A, d)
+broadcasted(::DomainSetStyle, ::typeof(approx_in), A, d::Domain) = vectorized_approx_in(A, d)
+broadcasted(::DomainSetStyle, ::typeof(approx_in), A, d::Domain, tol) = vectorized_approx_in(A, d, tol)
+
+broadcasted(::DomainSetStyle, ::typeof(∉), A, d::Domain) = A .∉ Ref(d)
+
+@deprecate broadcast_in(A, d::Domain) vectorized_in(A, d)
+@deprecate broadcast_approx_in(A, d::Domain) vectorized_approx_in(A, d)
+@deprecate broadcast_approx_in(A, d::Domain, tol) vectorized_approx_in(A, d, tol)
 
 "Vectorized version of `in`: apply `x ∈ d` to all elements of `A`."
-broadcast_in(A, d::Domain) = in.(A, Ref(d))
+vectorized_in(A, d::Domain) = in.(A, Ref(d))
 
 "Vectorized version of `approx_in`: apply `x ∈ d` to all elements of `A`."
-broadcast_approx_in(A, d::Domain, tol) = approx_in.(A, Ref(d), tol)
+vectorized_approx_in(A, d::Domain) = approx_in.(A, Ref(d))
+vectorized_approx_in(A, d::Domain, tol) = approx_in.(A, Ref(d), tol)
 
 
 ## Some arithmetics

--- a/test/test_generic_domain.jl
+++ b/test/test_generic_domain.jl
@@ -106,11 +106,15 @@ end
             @test_logs (:warn, "`in`: incompatible combination of point: Tuple{Float64, Float64} and domain eltype: SVector{2, Float64}. Returning false.") approx_in((0.5,0.2), UnitCircle())
         end
 
-        # some functionality in broadcast
+        # functionality using broadcast
         @test 2 * (1..2) == 2 .* (1..2)
         @test (1..2) * 2 == (1..2) .* 2
         @test (1..2) / 2 ≈ (0.5..1)
         @test 2 \ (1..2) ≈ (0.5..1)
+        @test all(rand(4) .∈ (-1..1))
+        @test all(approx_in.(rand(4), -1..1))
+        @test all(approx_in.([1.005,1.0005], -1..1, [1e-2,1e-3]))
+        @test all(rand(4) .∉ (2..3))
         @test_throws MethodError (0..1) + 0.4
 
         # promotion


### PR DESCRIPTION
We had the following asymmetric situation, where broadcast would work for `in` but not for `∉`:
```julia
julia> using DomainSets

julia> rand(2) .∈ (0..1)
2-element BitVector:
 1
 1

julia> rand(2) .∉ (0..1)
ERROR: MethodError: no method matching size(::ClosedInterval{Int64})
```
This PR adds broadcast functionality for the `∉` method. The result is equivalent to typing `A .∉ Ref(0..1)` instead.

Currently, domains participate in broadcast using `DomainSetStyle` as broadcaststyle. A few functions, like `in` and `∉` are now supported by intercepting them during broadcast. There might be a more generic way to do it, but I didn't see it. In any case, using domains in conjunction with broadcast is possible by using `Ref(d)`. We may want to be conservative in allowing just `d` instead, and `in` and `∉` seem two valid special cases.