### PR TITLE
Fix broken show tests

### DIFF
--- a/test/test_domain_interval.jl
+++ b/test/test_domain_interval.jl
@@ -99,7 +99,7 @@ function test_intervals()
         @test canonicaldomain(d) === d
 
         show(io, ChebyshevInterval())
-        @test String(take!(io)) == "-1.0..1.0 (Chebyshev)"
+        @test String(take!(io)) == "$(-1.0..1.0) (Chebyshev)"
     end
     @testset "HalfLine{$T}" begin
         d = HalfLine{T}()

--- a/test/test_domain_product.jl
+++ b/test/test_domain_product.jl
@@ -22,7 +22,7 @@ function test_product_domains()
         @test VcatDomain( (-1..1, -2..2)) isa VcatDomain{2,Int,(1,1),Tuple{ClosedInterval{Int64}, ClosedInterval{Int64}}}
 
         show(io,d1)
-        @test String(take!(io)) == "(-1.0..1.0) × (-1.0..1.0)"
+        @test String(take!(io)) == "($(-1.0..1.0)) × ($(-1.0..1.0))"
 
         bnd = boundary(d1)
         @test bnd isa EuclideanDomain
@@ -37,10 +37,10 @@ function test_product_domains()
         @test VcatDomain(UnitCircle()) isa VcatDomain{2}
 
         # Test vectors of wrong length
-        @test_logs (:warn, "`in`: incompatible combination of vector with length 3 and domain '(-1.0..1.0) × (-1.0..1.0)' with dimension 2. Returning false.") SA[0.0,0.0,0.0] ∉ d1
-        @test_logs (:warn, "`in`: incompatible combination of vector with length 1 and domain '(-1.0..1.0) × (-1.0..1.0)' with dimension 2. Returning false.") SA[0.0] ∉ d1
-        @test_logs (:warn, "`in`: incompatible combination of vector with length 3 and domain '(-1.0..1.0) × (-1.0..1.0)' with dimension 2. Returning false.") [0.0,0.0,0.0] ∉ d1
-        @test_logs (:warn, "`in`: incompatible combination of vector with length 1 and domain '(-1.0..1.0) × (-1.0..1.0)' with dimension 2. Returning false.") [0.0] ∉ d1
+        @test_logs (:warn, "`in`: incompatible combination of vector with length 3 and domain '($(-1.0..1.0)) × ($(-1.0..1.0))' with dimension 2. Returning false.") SA[0.0,0.0,0.0] ∉ d1
+        @test_logs (:warn, "`in`: incompatible combination of vector with length 1 and domain '($(-1.0..1.0)) × ($(-1.0..1.0))' with dimension 2. Returning false.") SA[0.0] ∉ d1
+        @test_logs (:warn, "`in`: incompatible combination of vector with length 3 and domain '($(-1.0..1.0)) × ($(-1.0..1.0))' with dimension 2. Returning false.") [0.0,0.0,0.0] ∉ d1
+        @test_logs (:warn, "`in`: incompatible combination of vector with length 1 and domain '($(-1.0..1.0)) × ($(-1.0..1.0))' with dimension 2. Returning false.") [0.0] ∉ d1
 
         d3 = VcatDomain(-1.0 .. 1.0, -1.5 .. 2.5)
         @test SA[0.5,0.5] ∈ d3
@@ -318,7 +318,7 @@ function test_product_domains()
         # Generic functionality
         long_domain = ProductDomain([0..i for i in 1:20])
         show(io, long_domain)
-        @test String(take!(io)) == "(0..1) × (0..2) × (0..3) × ... × (0..20)"
+        @test String(take!(io)) == "($(0..1)) × ($(0..2)) × ($(0..3)) × ... × ($(0..20))"
         @test isopenset(interior(UnitCube()))
         @test isclosedset(closure(interior(UnitCube())))
     end

--- a/test/test_readme.jl
+++ b/test/test_readme.jl
@@ -2,12 +2,12 @@
 
 @testset "examples" begin
     using DomainSets, StaticArrays
-    @test repr(UnitInterval()) == "0.0..1.0 (Unit)"
-    @test repr(ChebyshevInterval()) == "-1.0..1.0 (Chebyshev)"
-    @test repr(HalfLine()) == "0.0..Inf (closed–open) (HalfLine)"
+    @test repr(UnitInterval()) == "$(0.0..1.0) (Unit)"
+    @test repr(ChebyshevInterval()) == "$(-1.0..1.0) (Chebyshev)"
+    @test repr(HalfLine()) == "$(0.0..Inf) (closed-open) (HalfLine)"
 
     using DomainSets: ×
-    @test repr((-1..1) × (0..3) × (4.0..5.0)) == "(-1.0..1.0) × (0.0..3.0) × (4.0..5.0)"
+    @test repr((-1..1) × (0..3) × (4.0..5.0)) == "($(-1.0..1.0)) × ($(0.0..3.0)) × ($(4.0..5.0))"
     @test SVector(1,2) in (-1..1) × (0..3)
 
     @test SVector(0,0,1.0) in UnitSphere(Val(3))

--- a/test/test_setoperations.jl
+++ b/test/test_setoperations.jl
@@ -94,7 +94,7 @@
 
         @test !isempty(u1)
         show(io, textmime, u1)
-        @test String(take!(io)) == "UnitDisk() ∪ ((-0.9..0.9) × (-0.9..0.9))"
+        @test String(take!(io)) == "UnitDisk() ∪ (($(-0.9..0.9)) × ($(-0.9..0.9)))"
 
         # repeated union
         @test ncomponents(uniondomain(UnitBall{Float64}(), UnitInterval(), UnitInterval())) == 2
@@ -114,11 +114,11 @@
         i1 = intersectdomain((-0.4..0.4)^2, (-.5 .. 0.5) × (-0.1.. 0.1))
         @test i1 == productdomain(-0.4..0.4, -0.1..0.1)
         show(io,i1)
-        @test String(take!(io)) == "(-0.4..0.4) × (-0.1..0.1)"
+        @test String(take!(io)) == "($(-0.4..0.4)) × ($(-0.1..0.1))"
         @test intersectdomain(productdomain(UnitDisk(),-1..1), productdomain(-1..1, UnitDisk())) isa IntersectDomain
         i2 = UnitDisk() & (-0.4..0.4)^2
         show(io, textmime, i2)
-        @test String(take!(io)) == "UnitDisk() ∩ ((-0.4..0.4) × (-0.4..0.4))"
+        @test String(take!(io)) == "UnitDisk() ∩ (($(-0.4..0.4)) × ($(-0.4..0.4)))"
         @test dimension(i1) == 2
         @test dimension(i2) == 2
 
@@ -176,7 +176,7 @@
         @test SVector(1.01, 0.1) ∉ d1
         @test approx_in(SVector(1.01, 0.1), d1, 0.1)
         show(io, textmime, d1)
-        @test String(take!(io)) == "UnitDisk() \\ ((-0.5..0.5) × (-0.1..0.1))"
+        @test String(take!(io)) == "UnitDisk() \\ (($(-0.5..0.5)) × ($(-0.1..0.1)))"
         @test setdiff(d1, ProductDomain(-0.5..0.5, -0.1..0.1)) == d1
 
         d2 = SetdiffDomain(0.0..3.0, [1.0, 2.5])

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -596,7 +596,7 @@ include("test_domain_simplex.jl")
         @test -0.5 ∉ d2
         @test 0.5 ∈ d2
         show(io, d2)
-        @test String(take!(io)) == "indicator function bounded by: -1..1"
+        @test String(take!(io)) == "indicator function bounded by: $(-1..1)"
 
         d3 = Domain(x*y>0 for (x,y) in UnitDisk())
         @test eltype(d3) == SVector{2,Float64}


### PR DESCRIPTION
Many of the `show` tests were broken (possibly due to upstream change in https://github.com/JuliaMath/IntervalSets.jl/pull/135), and this PR fixes these. Tests pass locally after this.