### PR TITLE
Use invoke function instead of macro

### DIFF
--- a/src/generic/canonical.jl
+++ b/src/generic/canonical.jl
@@ -157,4 +157,4 @@ isequaldomain(d1::BaseDomainType, d2::BaseDomainType) = d1 ⊆ d2 && d2 ⊆ d1
 hash(d::Domain, h::UInt) = domainhash(simplify(d), h)
 
 domainhash(d) = domainhash(d, zero(UInt))
-domainhash(d, h::UInt) = @invoke hash(d::Any, h::UInt)
+domainhash(d, h::UInt) = invoke(hash, Tuple{Any,UInt}, d, h)

--- a/src/maps/map.jl
+++ b/src/maps/map.jl
@@ -147,7 +147,7 @@ default_isequalmap(m1, m2) = m1===m2
 
 hash(m::AbstractMap, h::UInt) = map_hash(m, h)
 map_hash(m) = map_hash(m, zero(UInt))
-map_hash(m, h::UInt) = @invoke hash(m::Any, h::UInt)
+map_hash(m, h::UInt) = invoke(hash, Tuple{Any,UInt}, m, h)
 
 # Display routines
 map_stencil(m, x) = [Display.SymbolObject(m), '(', x, ')']


### PR DESCRIPTION
The macro was introduced in julia v1.7, so for compatibility with v1.6, we need to use the function.