### PR TITLE
make abstract arrays work like a linear map

### DIFF
--- a/FunctionMaps/src/generic/canonical.jl
+++ b/FunctionMaps/src/generic/canonical.jl
@@ -30,9 +30,17 @@ canonicalmap(::Equal, m) = m
 equalmap(m) = canonicalmap(Equal(), m)
 hasequalmap(m) = hascanonicalmap(Equal(), m)
 
-"Simplify the given map to an equal map."
+"""
+    simplify(m)
+
+Simplify the given map to an equal map.
+"""
 simplify(m) = equalmap(m)
-"Does the map simplify?"
+"""
+    simplifies(m)
+
+Does the map simplify?
+"""
 simplifies(m) = hasequalmap(m)
 
 "Convert the given map to a map defined in FunctionMaps.jl."
@@ -69,7 +77,11 @@ canonicalextensiontype(m) = canonicalextensiontype(typeof(m))
 
 ==(m1::Map, m2::Map) = isequalmap(m1, m2)   # Method from Base
 
-"Are the two given maps equal?"
+"""
+    isequalmap(map1, map2)
+
+Are the two given maps equal?
+"""
 isequalmap(m1, m2) = isequalmap1(m1, m2)
 isequalmap1(m1, m2) = simplifies(m1) ? isequalmap(simplify(m1), m2) : isequalmap2(m1, m2)
 isequalmap2(m1, m2) = simplifies(m2) ? isequalmap(m1, simplify(m2)) : default_isequalmap(m1, m2)

--- a/FunctionMaps/src/generic/canonical.jl
+++ b/FunctionMaps/src/generic/canonical.jl
@@ -49,7 +49,7 @@ struct Equivalent <: CanonicalType end
 
 canonicalmap(::Equivalent, m) = canonicalmap(Equal(), m)
 
-canonicalmap(::Equivalent, m::Map{SVector{1,T}}) where {T} = convert(Map{T}, m)
+canonicalmap(::Equivalent, m::Map{<:StaticVector{1,T}}) where {T} = convert(Map{T}, m)
 canonicalmap(::Equivalent, m::Map{NTuple{N,T}}) where {N,T} = convert(Map{SVector{N,T}}, m)
 
 equivalentmap(m) = canonicalmap(Equivalent(), m)

--- a/FunctionMaps/src/generic/composite.jl
+++ b/FunctionMaps/src/generic/composite.jl
@@ -97,6 +97,8 @@ map_hash(m::ComposedMap, h::UInt) = hashrec("ComposedMap", collect(components(m)
 Display.combinationsymbol(m::ComposedMap) = Display.Symbol('∘')
 Display.displaystencil(m::ComposedMap) =
     composite_displaystencil(m; reversecomponents=true)
+map_object_parentheses(m::ComposedMap) = true
+map_stencil_parentheses(m::ComposedMap) = true
 show(io::IO, mime::MIME"text/plain", m::ComposedMap) = composite_show(io, mime, m)
 show(io::IO, m::ComposedMap) = composite_show_compact(io, m)
 

--- a/FunctionMaps/src/generic/isomorphism.jl
+++ b/FunctionMaps/src/generic/isomorphism.jl
@@ -7,7 +7,7 @@ An isomorphism is a bijection between types that preserves norms.
 abstract type Isomorphism{T,U} <: TypedMap{T,U} end
 
 show(io::IO, m::Isomorphism{T,U}) where {T,U} = print(io, "x : $(T) -> x : $(U)")
-Display.object_parentheses(m::Isomorphism) = true
+map_object_parentheses(m::Isomorphism) = true
 
 struct VectorToNumber{T} <: Isomorphism{SVector{1,T},T}
 end

--- a/FunctionMaps/src/generic/jacobian.jl
+++ b/FunctionMaps/src/generic/jacobian.jl
@@ -14,7 +14,7 @@ show(io::IO, mime::MIME"text/plain", m::LazyJacobian) = composite_show(io, mime,
 
 
 """
-    jacobian(m::AbstractMap[, x])
+    jacobian(m[, x])
 
 Return the jacobian map. The two-argument version evaluates the jacobian
 at a point `x`.
@@ -168,7 +168,7 @@ zeromatrix(m, ::Type{T}, ::Type{U}) where {T<:AbstractVector,U<:Number} =
 "Return a zero vector of the same size as the codomain of the map."
 zerovector(m) = zerovector(m, codomaintype(m))
 zerovector(m, ::Type{U}) where {U} = zero(U)
-zerovector(m, ::Type{StaticVector{M,T}}) where {M,T} = zero(SVector{M,T})
+zerovector(m, ::Type{<:StaticVector{M,T}}) where {M,T} = zero(SVector{M,T})
 # If the output type is a vector, the map itself should store the size information.
 zerovector(m, ::Type{<:AbstractVector{T}}) where {T} = zeros(T, mapsize(m,1))
 

--- a/FunctionMaps/src/generic/jacobian.jl
+++ b/FunctionMaps/src/generic/jacobian.jl
@@ -124,8 +124,8 @@ Convert the `A` in the affine map `A*x` or `A*x+b` with domaintype `T` to a matr
 to_matrix(::Type{T}, A) where {T} = A
 to_matrix(::Type{T}, A::AbstractMatrix) where {T} = A
 to_matrix(::Type{T}, A::NumberLike) where {T<:Number} = A
-to_matrix(::Type{SVector{N,T}}, A::Number) where {N,T} = A * one(SMatrix{N,N,T})
-to_matrix(::Type{SVector{N,T}}, A::UniformScaling) where {N,T} = A.λ * one(SMatrix{N,N,T})
+to_matrix(::Type{<:StaticVector{N,T}}, A::Number) where {N,T} = A * one(SMatrix{N,N,T})
+to_matrix(::Type{<:StaticVector{N,T}}, A::UniformScaling) where {N,T} = A.λ * one(SMatrix{N,N,T})
 to_matrix(::Type{T}, A::Number) where {T<:AbstractVector} = A * I
 to_matrix(::Type{T}, A::UniformScaling) where {T<:Number} = one(T)
 to_matrix(::Type{T}, A::UniformScaling) where {T<:AbstractVector} = A
@@ -135,7 +135,7 @@ to_matrix(::Type{T}, A::AbstractMatrix, b) where {T} = A
 to_matrix(::Type{T}, A::Number, b::Number) where {T<:Number} = A
 to_matrix(::Type{T}, A::UniformScaling{S}, b::Number) where {S,T<:Number} =
 	convert(promote_type(S,T,typeof(b)), A.λ)
-to_matrix(::Type{SVector{N,T}}, A::NumberLike, b::SVector{N,T}) where {N,T} = A * one(SMatrix{N,N,T})
+to_matrix(::Type{<:StaticVector{N,T}}, A::NumberLike, b::StaticVector{N,T}) where {N,T} = A * one(SMatrix{N,N,T})
 to_matrix(::Type{T}, A::NumberLike, b::AbstractVector) where {S,T<:AbstractVector{S}} =
     A * Array{S,2}(I, length(b), length(b))
 
@@ -145,8 +145,8 @@ to_matrix(::Type{T}, A::NumberLike, b::AbstractVector) where {S,T<:AbstractVecto
 Convert the `b` in the affine map `A*x` or `A*x+b` with domaintype `T` to a vector.
 """
 to_vector(::Type{T}, A) where {T} = zero(T)
-to_vector(::Type{T}, A::SVector{M,S}) where {T,M,S} = zero(SVector{M,S})
-to_vector(::Type{T}, A::SMatrix{M,N,S}) where {T,M,N,S} = zero(SVector{M,S})
+to_vector(::Type{T}, A::StaticVector{M,S}) where {T,M,S} = zero(SVector{M,S})
+to_vector(::Type{T}, A::StaticMatrix{M,N,S}) where {T,M,N,S} = zero(SVector{M,S})
 to_vector(::Type{T}, A::AbstractArray) where {T} = zeros(eltype(T),size(A,1))
 to_vector(::Type{T}, A, b) where {T} = b
 

--- a/FunctionMaps/src/generic/map.jl
+++ b/FunctionMaps/src/generic/map.jl
@@ -27,14 +27,11 @@ domaintype(::Type{<:Map{T}}) where {T} = T
 What is the codomain type of the function map `m`, given that `T` is its domain type?
 """
 codomaintype(m) = codomaintype(m, domaintype(m))
-codomaintype(m, ::Type{T}) where {T} = codomaintype(typeof(m), T)
-
-codomaintype(::Type{M}, ::Type{T}) where {M,T} = Any
-codomaintype(::Type{M}, ::Type{Any}) where {M} = Any
-codomaintype(M::Type{<:AbstractMap}, ::Type{T}) where {T} = Base.promote_op(applymap, M, T)
-codomaintype(M::Type{<:AbstractMap}, ::Type{Any}) = Any
-codomaintype(M::Type{<:TypedMap{T,U}}, ::Type{T}) where {T,U} = U
-codomaintype(M::Type{<:TypedMap{T,U}}, ::Type{Any}) where {T,U} = U
+codomaintype(m, ::Type{T}) where {T} = _codomaintype(typeof(m), T)
+_codomaintype(::Type{M}, ::Type{T}) where {M,T} = Base.promote_op(applymap, M, T)
+_codomaintype(::Type{M}, ::Type{Any}) where {M} = Any
+_codomaintype(M::Type{<:TypedMap{T,U}}, ::Type{T}) where {T,U} = U
+_codomaintype(M::Type{<:TypedMap{T,U}}, ::Type{Any}) where {T,U} = U
 
 prectype(::Type{<:Map{T}}) where T = prectype(T)
 numtype(::Type{<:Map{T}}) where T = numtype(T)
@@ -53,6 +50,9 @@ convert_domaintype(::Type{T}, map::Map{T}) where {T} = map
 convert_domaintype(::Type{U}, map::Map{T}) where {T,U} = convert(Map{U}, map)
 convert_domaintype(::Type{Any}, map) = map
 convert_domaintype(::Type{Any}, map::Map{T}) where T = map
+convert_domaintype(::Type{T}, map) where T = _convert_domaintype(T, map, domaintype(map))
+_convert_domaintype(::Type{T}, map, ::Type{T}) where T = map
+_convert_domaintype(::Type{U}, map, ::Type{T}) where {T,U} = Map{U}(map)
 
 convert_numtype(::Type{U}, map::Map{T}) where {T,U} = convert(Map{to_numtype(U,T)}, map)
 convert_prectype(::Type{U}, map::Map{T}) where {T,U} = convert(Map{to_prectype(U,T)}, map)

--- a/FunctionMaps/src/generic/map.jl
+++ b/FunctionMaps/src/generic/map.jl
@@ -61,14 +61,18 @@ convert_codomaintype(::Type{U}, map) where U =
     _convert_codomaintype(U, map, domaintype(map), codomaintype(map))
 # types match: we can return map
 _convert_codomaintype(::Type{U}, map, ::Type{T}, ::Type{U}) where {T,U} = map
-# types don't match: we first convert the numtype
+# ...or, outputs are vectors with the same eltype: that's good enough, further
+# conversion might be unnecessary and expensive
+_convert_codomaintype(::Type{<:AbstractVector{S}}, map, ::Type{T}, ::Type{<:AbstractVector{S}}) where {T,S} = map
+# no match yet: we now try to convert the numtype
 _convert_codomaintype(::Type{U}, map, ::Type{T}, ::Type{V}) where {T,U,V} =
     _convert_codomaintype2(U, convert_numtype(numtype(U), map))
 _convert_codomaintype2(::Type{U}, map::Map) where U =
     _convert_codomaintype2(U, map, domaintype(map), codomaintype(map))
-# types match this time around: we can return map
+# better match this time around: we can return map
 _convert_codomaintype2(::Type{U}, map, ::Type{T}, ::Type{U}) where {T,U} = map
-# types don't match: we can't do this automatically
+_convert_codomaintype2(::Type{<:AbstractVector{S}}, map, ::Type{T}, ::Type{<:AbstractVector{S}}) where {T,S} = map
+# still no match: we can't do this automatically
 _convert_codomaintype2(::Type{U}, map, ::Type{T}, ::Type{V}) where {T,U,V} =
     throw(ArgumentError("Don't know how to convert the codomain type of $(map) to $(U)."))
 

--- a/FunctionMaps/src/generic/map.jl
+++ b/FunctionMaps/src/generic/map.jl
@@ -16,7 +16,11 @@ const VectorMap{T} = Map{Vector{T}}
 
 CompositeTypes.Display.displaysymbol(m::Map) = 'F'
 
-"What is the expected type of a point in the domain of the function map `m`?"
+"""
+    domaintype(m)
+
+What is the expected type of a point in the domain of the function map `m`?
+"""
 domaintype(m) = domaintype(typeof(m))
 domaintype(::Type{M}) where {M} = Any
 domaintype(::Type{<:Map{T}}) where {T} = T
@@ -163,3 +167,10 @@ is_vector_to_vector(m) = mapsize(m) isa Tuple{Int,Int} && !is_vector_to_scalar(m
 # Display routines
 map_stencil(m, x) = [Display.SymbolObject(m), '(', x, ')']
 map_stencil_broadcast(m, x) = [Display.SymbolObject(m), ".(", x, ')']
+map_stencil_broadcast(m::Function, x) = [repr(m), ".(", x, ')']
+
+Display.object_parentheses(m::Map) = map_object_parentheses(m)
+Display.stencil_parentheses(m::Map) = map_stencil_parentheses(m)
+
+map_object_parentheses(m) = false
+map_stencil_parentheses(m) = false

--- a/FunctionMaps/src/generic/product.jl
+++ b/FunctionMaps/src/generic/product.jl
@@ -90,6 +90,8 @@ canonicalmap(::Equivalent, m::ProductMap) = any(map(hasequivalentmap, factors(m)
 
 Display.combinationsymbol(m::ProductMap) = Display.Symbol('⊗')
 Display.displaystencil(m::ProductMap) = composite_displaystencil(m)
+map_object_parentheses(m::ProductMap) = true
+map_stencil_parentheses(m::ProductMap) = true
 show(io::IO, mime::MIME"text/plain", m::ProductMap) = composite_show(io, mime, m)
 show(io::IO, m::ProductMap) = composite_show_compact(io, m)
 

--- a/FunctionMaps/src/generic/product.jl
+++ b/FunctionMaps/src/generic/product.jl
@@ -8,10 +8,10 @@ abstract type ProductMap{T} <: CompositeLazyMap{T} end
 components(m::ProductMap) = m.maps
 factors(d::ProductMap) = components(d)
 
-VcatMapElement = Union{Map{<:SVector},Map{<:Number}}
+VcatMapElement = Union{Map{<:StaticVector},Map{<:Number}}
 
 ProductMap(maps::Tuple) = ProductMap(maps...)
-ProductMap(maps::SVector) = ProductMap(maps...)
+ProductMap(maps::StaticVector) = ProductMap(maps...)
 ProductMap(maps...) = TupleProductMap(maps...)
 ProductMap(maps::VcatMapElement...) = VcatMap(maps...)
 ProductMap(maps::AbstractVector) = VectorProductMap(maps)

--- a/FunctionMaps/src/types/affine.jl
+++ b/FunctionMaps/src/types/affine.jl
@@ -83,8 +83,8 @@ map_stencil_broadcast(m::AbstractAffineMap, x) = _affine_map_stencil_broadcast(m
 _affine_map_stencil_broadcast(m, x, A, b) = [A, " .* ", x, " .+ ", b]
 _affine_map_stencil_broadcast(m, x, A::Number, b) = [A, " * ", x, " .+ ", b]
 
-Display.object_parentheses(m::AbstractAffineMap) = true
-Display.stencil_parentheses(m::AbstractAffineMap) = true
+map_object_parentheses(m::AbstractAffineMap) = true
+map_stencil_parentheses(m::AbstractAffineMap) = true
 
 ########################
 # Linear maps: y = A*x

--- a/FunctionMaps/src/types/basic.jl
+++ b/FunctionMaps/src/types/basic.jl
@@ -41,7 +41,7 @@ mapcompose(m1::IdentityMap, maps...) = mapcompose(maps...)
 mapcompose2(m1, m2::IdentityMap, maps...) = mapcompose(m1, maps...)
 
 show(io::IO, m::IdentityMap{T}) where {T} = print(io, "x -> x")
-Display.object_parentheses(m::IdentityMap) = true
+map_object_parentheses(m::IdentityMap) = true
 
 "The identity map for variables of type `T`."
 struct StaticIdentityMap{T} <: IdentityMap{T}
@@ -130,7 +130,7 @@ ConstantMap{T,U}() where {T,U} = UnityMap{T,U}()
 ConstantMap{T,U}(c) where {T,U} = FixedConstantMap{T,U}(c)
 
 show(io::IO, m::ConstantMap{T}) where {T} = print(io, "x -> $(mapconstant(m))")
-Display.object_parentheses(m::ConstantMap) = true
+map_object_parentheses(m::ConstantMap) = true
 
 
 "The zero map `f(x) = 0`."

--- a/FunctionMaps/src/util/common.jl
+++ b/FunctionMaps/src/util/common.jl
@@ -86,8 +86,11 @@ Return the type to which `T` can be converted, such that the `prectype` becomes 
 to_prectype(::Type{U}, ::Type{T}) where {T,U} = throw(ArgumentError("Don't know how to convert the prectype of $(T) to $(U)."))
 to_prectype(::Type{U}, ::Type{T}) where {T <: Real,U <: Real} = U
 to_prectype(::Type{U}, ::Type{Complex{T}}) where {T <: Real,U <: Real} = Complex{U}
-to_prectype(::Type{U}, ::Type{SVector{N,T}}) where {N,T,U} = SVector{N,to_prectype(U,T)}
 to_prectype(::Type{U}, ::Type{Vector{T}}) where {T,U} = Vector{to_prectype(U,T)}
+to_prectype(::Type{U}, ::Type{<:StaticVector{N,T}}) where {N,T,U} = SVector{N,to_prectype(U,T)}
+to_prectype(::Type{U}, ::Type{MVector{N,T}}) where {N,T,U} = MVector{N,to_prectype(U,T)}
+to_prectype(::Type{U}, ::Type{<:StaticMatrix{M,N,T}}) where {M,N,T,U} = SMatrix{M,N,to_prectype(U,T)}
+to_prectype(::Type{U}, ::Type{MMatrix{M,N,T}}) where {M,N,T,U} = MMatrix{M,N,to_prectype(U,T)}
 
 """
 	promote_prectype(a, b[, ...])
@@ -136,8 +139,11 @@ Return the type to which `T` can be converted, such that the `numtype` becomes `
 """
 to_numtype(::Type{U}, ::Type{T}) where {T,U} = throw(ArgumentError("Don't know how to convert the numtype of $(T) to $(U)."))
 to_numtype(::Type{U}, ::Type{T}) where {T <: Number,U <: Number} = U
-to_numtype(::Type{U}, ::Type{SVector{N,T}}) where {N,T,U} = SVector{N,to_numtype(U,T)}
 to_numtype(::Type{U}, ::Type{Vector{T}}) where {T,U} = Vector{to_numtype(U,T)}
+to_numtype(::Type{U}, ::Type{<:StaticVector{N,T}}) where {N,T,U} = SVector{N,to_numtype(U,T)}
+to_numtype(::Type{U}, ::Type{MVector{N,T}}) where {N,T,U} = MVector{N,to_numtype(U,T)}
+to_numtype(::Type{U}, ::Type{<:StaticMatrix{M,N,T}}) where {M,N,T,U} = SMatrix{M,N,to_numtype(U,T)}
+to_numtype(::Type{U}, ::Type{MMatrix{M,N,T}}) where {M,N,T,U} = MMatrix{M,N,to_numtype(U,T)}
 
 """
 	promote_numtype(a, b[, ...])
@@ -177,7 +183,7 @@ end
 # we use matrix_pinv rather than pinv to preserve static matrices
 matrix_pinv(A) = pinv(A)
 # matrix_pinv(A::SMatrix{M,N}) where {M,N} = SMatrix{N,M}(pinv(A))
-matrix_pinv(A::SVector{N}) where {N} = convert(Transpose{Float64, SVector{N,Float64}}, pinv(A))
+matrix_pinv(A::StaticVector{N}) where {N} = convert(Transpose{Float64, SVector{N,Float64}}, pinv(A))
 
 ## Composite objects
 

--- a/FunctionMaps/test/test_affine.jl
+++ b/FunctionMaps/test/test_affine.jl
@@ -29,6 +29,7 @@ function test_affine_maps(T)
     test_linearmap(T)
     test_translation(T)
     test_affinemap(T)
+    test_abstractarraymap(T)
 end
 
 
@@ -210,4 +211,27 @@ function test_affinemap(T)
     @test StaticAffineMap(SMatrix{3,2,T}(1,2,3,4,5,6),SVector{3,T}(1,2,3)) isa StaticAffineMap{T,2,3,6}
 
     @test convert(Map{SVector{2,T}}, AffineMap(rand(2,2),rand(2))) isa StaticAffineMap{T,2,2,4}
+end
+
+function test_abstractarraymap(T)
+    A = rand(T, 3, 3)
+    @test FunctionMaps.MapStyle(A) isa FunctionMaps.IsMap
+    @test FunctionMaps.checkmap(A) == A
+    @test Map(A) isa LinearMap
+    @test Map(A) isa VectorLinearMap
+    @test Map(SA[1 2; 3 4]) isa StaticLinearMap
+    @test Map(Diagonal(rand(3))) isa GenericLinearMap
+    @test mapsize(A) == size(A)
+    @test applymap(A, 1:3) == A*(1:3)
+    @test islinearmap(A)
+    @test isaffinemap(A)
+    @test affinematrix(A) == A
+    @test affinevector(A) == [0,0,0]
+    @test jacobian(A) isa ConstantMap
+    @test jacobian(A, 1:3) == A
+    @test inverse(A) ≈ inv(A)
+    @test inverse(A, 1:3) ≈ A \ (1:3)
+    @test canonicalmap(A) isa LinearMap
+    @test FunctionMaps.equalmap(A) isa LinearMap
+    @test isequalmap(A, LinearMap(A))
 end

--- a/FunctionMaps/test/test_common.jl
+++ b/FunctionMaps/test/test_common.jl
@@ -32,6 +32,12 @@ function test_prectype()
     @test convert_prectype(BigFloat, 1.0+im) isa Complex{BigFloat}
     @test convert_prectype(Float64, SA[1,2]) == SA[1.0,2.0]
     @test convert_prectype(Float64, SA[1,2]) isa SVector{2,Float64}
+    @test convert_prectype(Float64, MVector(1,2)) == MVector(1.0,2.0)
+    @test convert_prectype(Float64, MVector(1,2)) isa MVector
+    @test convert_prectype(Float64, SA[1 2; 3 4]) == SA[1.0 2.0; 3.0 4.0]
+    @test convert_prectype(Float64, SA[1 2; 3 4]) isa SMatrix{2,2,Float64}
+    @test convert_prectype(Float64, MMatrix{2,2}(1, 2, 3, 4)) == SA[1.0 3.0; 2.0 4.0]
+    @test convert_prectype(Float64, MMatrix{2,2}(1, 2, 3, 4)) isa MMatrix{2,2,Float64}
     @test convert_prectype(BigFloat, SA[1,2+im]) isa SVector{2,Complex{BigFloat}}
     @test_throws ArgumentError convert_prectype(BigFloat, "a")
 
@@ -63,8 +69,14 @@ function test_numtype()
 
     @test convert_numtype(Float64, 2) == 2
     @test convert_numtype(Float64, 2) isa Float64
-    @test convert_numtype(Float64, SA[1,2]) == SA[1,2]
+    @test convert_numtype(Float64, SA[1,2]) == SA[1.0,2.0]
     @test convert_numtype(Float64, SA[1,2]) isa SVector{2,Float64}
+    @test convert_numtype(Float64, MVector(1,2)) == MVector(1.0,2.0)
+    @test convert_numtype(Float64, MVector(1,2)) isa MVector
+    @test convert_numtype(Float64, SA[1 2; 3 4]) == SA[1.0 2.0; 3.0 4.0]
+    @test convert_numtype(Float64, SA[1 2; 3 4]) isa SMatrix{2,2,Float64}
+    @test convert_numtype(Float64, MMatrix{2,2}(1, 2, 3, 4)) == SA[1.0 3.0; 2.0 4.0]
+    @test convert_numtype(Float64, MMatrix{2,2}(1, 2, 3, 4)) isa MMatrix{2,2,Float64}
     @test_throws ArgumentError convert_numtype(BigFloat, "a")
 
     @test promote_numtype(2) == 2

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1.6"
 Aqua = "0.8"
 CompositeTypes = "0.1.2"
 IntervalSets = "0.7.4"
@@ -19,6 +18,7 @@ Random = "1"
 StableRNGs = "1"
 StaticArrays = "0.12.2, 1"
 Test = "1"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Aqua = "0.8"
-CompositeTypes = "0.1.2"
+CompositeTypes = "0.1.4"
 IntervalSets = "0.7.4"
 LinearAlgebra = "1"
 Random = "1"
 StableRNGs = "1"
-StaticArrays = "0.12.2, 1"
+StaticArrays = "1"
 Test = "1"
 julia = "1.6"
 

--- a/src/domains/ball.jl
+++ b/src/domains/ball.jl
@@ -570,13 +570,13 @@ closure(d::DynamicUnitBall{T}) where {T} = DynamicUnitBall{T,:closed}(dimension(
 closure(d::Ball{T}) where {T} = Ball{T,:closed}(radius(d), center(d))
 
 boundingbox(d::UnitBall{T}) where {T<:Number} = ChebyshevInterval{T}()
-boundingbox(d::UnitBall{SVector{N,T}}) where {N,T} =
+boundingbox(d::UnitBall{<:StaticVector{N,T}}) where {N,T} =
     ChebyshevProductDomain{N,T}()
 boundingbox(d::UnitBall{T}) where {T} =
     Rectangle{T}(-ones(eltype(T), dimension(d)), ones(eltype(T), dimension(d)))
 
 boundingbox(d::UnitSphere{T}) where {T<:Number} = ChebyshevInterval{T}()
-boundingbox(d::UnitSphere{SVector{N,T}}) where {N,T} =
+boundingbox(d::UnitSphere{<:StaticVector{N,T}}) where {N,T} =
     ChebyshevProductDomain{N,T}()
 boundingbox(d::UnitSphere{T}) where {T} =
     Rectangle{T}(-ones(eltype(T), dimension(d)), ones(eltype(T), dimension(d)))

--- a/src/domains/ball.jl
+++ b/src/domains/ball.jl
@@ -45,15 +45,21 @@ a subtype of `UnitBall` is returned, whose concrete type depends on `T`.
 
 A ball represents a volume. For the boundary of a ball, see [`Sphere()`](@ref).
 """
-Ball() = UnitBall()
-Ball{T}() where {T} = UnitBall{T}()
-Ball{T,C}() where {T,C} = UnitBall{T,C}()
-Ball(radius::Number) = GenericBall(radius)
-Ball{T}(radius::Number) where {T} = GenericBall{T}(radius)
-Ball{T,C}(radius::Number) where {T,C} = GenericBall{T,C}(radius)
-Ball(radius::Number, center) = GenericBall(radius, center)
-Ball{T}(radius::Number, center) where {T} = GenericBall{T}(radius, center)
-Ball{T,C}(radius::Number, center) where {T,C} = GenericBall{T,C}(radius, center)
+Ball(; radius=One(), center=Origin()) = Ball(radius, center)
+Ball(radius; center=Origin()) = Ball(radius, center)
+Ball(::One, ::Origin) = UnitBall()
+Ball(radius, center) = GenericBall(radius, center)
+Ball(::One, center) = GenericBall(1, center)
+Ball(radius, center::Origin) = GenericBall(radius)
+
+Ball{T}(args...; options...) where T = Ball{T,:closed}(args...; options...)
+
+Ball{T,C}(; radius = One(), center = Origin()) where {T,C} = Ball{T,C}(radius, center)
+Ball{T,C}(radius; center=Origin()) where {T,C} = Ball{T,C}(radius, center)
+Ball{T,C}(radius, center) where {T,C} = GenericBall{T,C}(radius, center)
+Ball{T,C}(::One, ::Origin) where {T,C} = UnitBall{T,C}()
+Ball{T,C}(radius::One, center) where {T,C} = GenericBall{T,C}(1, center)
+Ball{T,C}(radius, center::Origin) where {T,C} = GenericBall{T,C}(radius)
 
 
 indomain(x, d::OpenBall) = norm(x-center(d)) < radius(d)
@@ -350,12 +356,19 @@ a subtype of `UnitSphere` is returned, whose concrete type depends on `T`.
 
 A sphere represents the boundary of a ball. For the volume, see [`Ball()`](@ref).
 """
-Sphere() = UnitSphere()
-Sphere{T}() where {T} = UnitSphere{T}()
-Sphere(radius::Number) = GenericSphere(radius)
-Sphere{T}(radius::Number) where {T} = GenericSphere{T}(radius)
-Sphere(radius::Number, center) = GenericSphere(radius, center)
-Sphere{T}(radius::Number, center) where {T} = GenericSphere{T}(radius, center)
+Sphere(; radius=One(), center=Origin()) = Sphere(radius, center)
+Sphere(radius; center=Origin()) = Sphere(radius, center)
+Sphere(::One, ::Origin) = UnitSphere()
+Sphere(radius, center) = GenericSphere(radius, center)
+Sphere(::One, center) = GenericSphere(1, center)
+Sphere(radius, center::Origin) = GenericSphere(radius)
+
+Sphere{T}(; radius = One(), center = Origin()) where T = Sphere{T}(radius, center)
+Sphere{T}(radius; center=Origin()) where T = Sphere{T}(radius, center)
+Sphere{T}(radius, center) where T = GenericSphere{T}(radius, center)
+Sphere{T}(::One, ::Origin) where T = UnitSphere{T}()
+Sphere{T}(radius::One, center) where T = GenericSphere{T}(1, center)
+Sphere{T}(radius, center::Origin) where T = GenericSphere{T}(radius)
 
 isempty(::Sphere) = false
 

--- a/src/domains/simplex.jl
+++ b/src/domains/simplex.jl
@@ -165,14 +165,14 @@ similardomain(d::DynamicUnitSimplex{S,C}, ::Type{T}) where {S,T,C} =
     DynamicUnitSimplex{T,C}(d.dimension)
 
 
-simplex_face_map(a::Number, b::Number, c::SVector{2}, d::SVector{2}) =
+simplex_face_map(a::Number, b::Number, c::StaticVector{2}, d::StaticVector{2}) =
 	AffineMap((d-c)/(b-a), c - (d-c)/(b-a)*a)
 function simplex_face_map(a::Number, b::Number, c::Vector, d::Vector)
 	@assert length(c) == length(d) == 2
 	AffineMap((d-c)/(b-a), c - (d-c)/(b-a)*a)
 end
 
-function boundary(d::StaticUnitSimplex{SVector{2,T}}) where T
+function boundary(d::StaticUnitSimplex{<:StaticVector{2,T}}) where T
     d0 = UnitInterval{T}()
 	T0 = zero(T)
 	T1 = one(T)
@@ -185,7 +185,7 @@ function boundary(d::StaticUnitSimplex{SVector{2,T}}) where T
 	UnionDomain(faces)
 end
 
-# function boundary(d::StaticUnitSimplex{SVector{N,T},:closed}) where {N,T}
+# function boundary(d::StaticUnitSimplex{<:StaticVector{N,T},:closed}) where {N,T}
 # 	left2 = infimum(d)
 # 	right2 = supremum(d)
 # 	d0 = UnitSimplex{SVector{N-1,T},:closed}()

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -45,7 +45,7 @@ broadcasted(::DomainSetStyle, m::AbstractMap, d::AnyDomain) =
     map_domain(m, domain(d))
 
 broadcasted(::DomainSetStyle, fun::Function, d::AnyDomain) =
-    map_domain(fun, domain(d))
+    parametric_domain(fun, domain(d))
 
 # Intercept broadcast applied to `in`, e.g. in.(A, d).
 # This gives domains an opportunity to provide a more efficient implementation

--- a/src/generic/canonical.jl
+++ b/src/generic/canonical.jl
@@ -138,9 +138,9 @@ canonicaldomain(::Isomorphic, d) = canonicaldomain(Equal(), d)
 mapfrom_canonical(::Isomorphic, d) = mapfrom_canonical(Equal(), d)
 mapto_canonical(::Isomorphic, d) = leftinverse(mapfrom_canonical(Isomorphic(), d))
 
-canonicaldomain(::Isomorphic, d::Domain{SVector{1,T}}) where {T} =
+canonicaldomain(::Isomorphic, d::Domain{<:StaticVector{1,T}}) where {T} =
     convert(Domain{T}, d)
-mapfrom_canonical(::Isomorphic, d::Domain{SVector{1,T}}) where {T} =
+mapfrom_canonical(::Isomorphic, d::Domain{<:StaticVector{1,T}}) where {T} =
     NumberToVector{T}()
 
 canonicaldomain(::Isomorphic, d::Domain{NTuple{N,T}}) where {N,T} =

--- a/src/generic/mapped.jl
+++ b/src/generic/mapped.jl
@@ -77,7 +77,7 @@ forward_map(d::MappedDomain) = rightinverse(d.invmap)
 forward_map(d::MappedDomain, x) = rightinverse(d.invmap, x)
 
 inverse_map(d::MappedDomain) = d.invmap
-inverse_map(d::MappedDomain, y) = d.invmap(y)
+inverse_map(d::MappedDomain, y) = applymap(d.invmap, y)
 
 """
     map_domain(map, domain)
@@ -163,7 +163,7 @@ similardomain(d::ParametricDomain, ::Type{T}) where {T} =
     ParametricDomain{T}(d.fmap, d.domain)
 
 forward_map(d::ParametricDomain) = d.fmap
-forward_map(d::ParametricDomain, x) = d.fmap(x)
+forward_map(d::ParametricDomain, x) = applymap(d.fmap, x)
 
 function indomain(x, d::ParametricDomain)
     # To check for membership, we can't use the inverse map because it may not exist

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -58,7 +58,7 @@ closure(d::ProductDomain) = ProductDomain(map(closure, components(d)))
 center(d::ProductDomain) = toexternalpoint(d, map(center, components(d)))
 
 VcatDomainElement = Union{Domain{<:Number},EuclideanDomain}
-VcatEltype = Union{Type{<:Number},Type{<:SVector}}
+VcatEltype = Union{Type{<:Number},Type{<:StaticVector}}
 
 """
 	ProductDomain(domains...)
@@ -134,12 +134,12 @@ for CTYPE in (Parameterization, Equal)
 end
 
 # multiplication with a scalar number
-function map_domain(linmap::GenericLinearMap{SVector{N,S},A}, domain::ProductDomain{SVector{N,T}}) where {N,S,T,A<:Number}
+function map_domain(linmap::GenericLinearMap{<:StaticVector{N,S},A}, domain::ProductDomain{<:StaticVector{N,T}}) where {N,S,T,A<:Number}
 	c = unsafe_matrix(linmap)
 	ProductDomain{SVector{N,promote_type(S,T)}}(map(d -> c .* d, components(domain)))
 end
 
-function map_domain(transmap::Translation{SVector{N,S}}, domain::ProductDomain{SVector{N,T}}) where {N,S,T}
+function map_domain(transmap::Translation{<:StaticVector{N,S}}, domain::ProductDomain{<:StaticVector{N,T}}) where {N,S,T}
     vec = unsafe_vector(transmap)
     ProductDomain{SVector{N,promote_type(S,T)}}(
             map( (d,v) -> d .+ v, components(domain), tointernalpoint(domain, vec)))

--- a/src/util/common.jl
+++ b/src/util/common.jl
@@ -1,4 +1,18 @@
 
+"""
+	One()
+
+Representation of the number 1.
+"""
+const One = Val{1}
+
+"""
+	Origin()
+
+Representation of the origin.
+"""
+const Origin = Val{:origin}
+
 unitvector(d::Domain{T}, dim) where {N,S,T<:SVector{N,S}} = SVector{N,S}(ntuple(i -> i==dim, N))
 function unitvector(d::Domain{T}, dim) where {T<:AbstractVector}
     p = zeros(eltype(T), dimension(d))

--- a/test/test_domain_product.jl
+++ b/test/test_domain_product.jl
@@ -369,7 +369,6 @@ function test_product_domains()
         @test intersectbox(d1, d2) == ProductDomain(0.5..1.0, 2.5..4.0)
 
         @test boundingbox(MappedDomain(LinearMap(1/2), 2..3)) == 4.0..6.0
-        @test boundingbox(MappedDomain(LinearMap(1/2), (2..3)^2)) == (4.0..6.0)^2
     end
     @testset "product mapto" begin
         d1 = ProductDomain(1.0..2.0, 1.0..2.0)

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -2,6 +2,7 @@ using StaticArrays, DomainSets, Test
 
 using DomainSets:
     MappedDomain,
+    ParametricDomain,
     similar_interval,
     GenericBall, GenericSphere
 
@@ -414,7 +415,7 @@ include("test_domain_simplex.jl")
     @testset "mapped_domain" begin
         @test MappedDomain(cos, 0..1.0) isa MappedDomain{Float64}
         @test MappedDomain{Float64}(cos, 0..1.0) isa MappedDomain{Float64}
-        @test cos.(0..1.0) isa MappedDomain
+        @test cos.(0..1.0) isa ParametricDomain
         @test isempty(MappedDomain(LinearMap(2.0), EmptySpace()))
         @test mapped_domain(acos, 0..1.0) isa MappedDomain
 


### PR DESCRIPTION
This is a testcase for maps-as-an-interface.
With the current changes, one can use a matrix from Rotations.jl in the `map_domain` and `mapped_domain` functions to rotate a domain.