### PR TITLE
Use setup julia v2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2.2
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
This fetches the latest version of the script, which ensures that the LTS version pointed to is updated to v1.10 instead of using v1.6 