### PR TITLE
Docstring updates for `cartesianproduct` and `×`

### DIFF
--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -118,7 +118,10 @@ julia> using DomainSets: ×
 
 julia> (0..1) × (2..3)
 (0 .. 1) × (2 .. 3)
-````
+```
+
+!!! note
+	`cartesianproduct` requires at least v0.7.17 of DomainSets.jl.
 """
 cartesianproduct(d...) = productdomain(d...)
 × = cartesianproduct

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -124,6 +124,15 @@ julia> (0..1) × (2..3)
 	`cartesianproduct` requires at least v0.7.17 of DomainSets.jl.
 """
 cartesianproduct(d...) = productdomain(d...)
+
+"""
+	DomainSets.:(×)
+
+Alias for [`cartesianproduct`](@ref). Note that this differs from LinearAlgebra.:(×) that represents the cross product of vectors.
+
+!!! note
+	`×` requires at least v0.8.0 of DomainSets.jl.
+"""
 × = cartesianproduct
 
 Base.:^(d::Domain, n::Int) = productdomain(ntuple(i->d, n)...)


### PR DESCRIPTION
Since `cartesianproduct` is a recommended deprecation fix, it would be good to specify which version it's available from. Similarly, `×` is mentioned in the docs, so it'll be good to specify that v0.8 introduces its own function that differs from the `LinearAlgebra` one, and it is an alias for `cartesianproduct`.