### PR TITLE
Declare global names as `const`

### DIFF
--- a/src/domains/trivial.jl
+++ b/src/domains/trivial.jl
@@ -5,7 +5,7 @@
 struct EmptySpace{T} <: Domain{T}
 end
 
-EmptySet = EmptySpace
+const EmptySet = EmptySpace
 
 const AnyEmptySpace = EmptySpace{Any}
 

--- a/src/generic/interface.jl
+++ b/src/generic/interface.jl
@@ -66,7 +66,7 @@ DomainStyle(::Type{<:Number}) = IsDomain()
 DomainStyle(::Type{<:AbstractSet}) = IsDomain()
 DomainStyle(::Type{<:AbstractArray}) = IsDomain()
 
-BaseDomainType = Union{<:Number,<:AbstractSet,<:AbstractArray}
+const BaseDomainType = Union{<:Number,<:AbstractSet,<:AbstractArray}
 
 """
     domain(d)

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -57,8 +57,8 @@ closure(d::ProductDomain) = ProductDomain(map(closure, components(d)))
 
 center(d::ProductDomain) = toexternalpoint(d, map(center, components(d)))
 
-VcatDomainElement = Union{Domain{<:Number},EuclideanDomain}
-VcatEltype = Union{Type{<:Number},Type{<:StaticVector}}
+const VcatDomainElement = Union{Domain{<:Number},EuclideanDomain}
+const VcatEltype = Union{Type{<:Number},Type{<:StaticVector}}
 
 """
 	ProductDomain(domains...)

--- a/src/generic/productdomain.jl
+++ b/src/generic/productdomain.jl
@@ -133,7 +133,7 @@ Alias for [`cartesianproduct`](@ref). Note that this differs from LinearAlgebra.
 !!! note
 	`×` requires at least v0.8.0 of DomainSets.jl.
 """
-× = cartesianproduct
+const × = cartesianproduct
 
 Base.:^(d::Domain, n::Int) = productdomain(ntuple(i->d, n)...)
 


### PR DESCRIPTION
This helps with type inference.

On master
```julia
julia> d = ChebyshevInterval();

julia> f(d) = DomainSets.:(×)(d, d)
f (generic function with 1 method)

julia> @code_warntype f(d)
MethodInstance for f(::ChebyshevInterval{Float64})
  from f(d) @ Main REPL[5]:1
Arguments
  #self#::Core.Const(Main.f)
  d::Core.Const(-1.0 .. 1.0 (Chebyshev))
Body::Any
1 ─ %1 = Main.DomainSets::Core.Const(DomainSets)
│   %2 = Base.getproperty(%1, :×)::Any
│   %3 = (%2)(d, d)::Any
└──      return %3
``` 
with this pR
```julia
julia> @code_warntype f(d)
MethodInstance for f(::ChebyshevInterval{Float64})
  from f(d) @ Main REPL[3]:1
Arguments
  #self#::Core.Const(Main.f)
  d::Core.Const(-1.0 .. 1.0 (Chebyshev))
Body::DomainSets.FixedIntervalProduct{2, Float64, ChebyshevInterval{Float64}}
1 ─ %1 = Main.DomainSets::Core.Const(DomainSets)
│   %2 = Base.getproperty(%1, :×)::Core.Const(DomainSets.cartesianproduct)
│   %3 = (%2)(d, d)::Core.Const((-1.0 .. 1.0 (Chebyshev)) × (-1.0 .. 1.0 (Chebyshev)))
└──      return %3
```