### PR TITLE
Support ball in at origin with autodiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DomainSets"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 CompositeTypes = "b152e2b5-7a66-4b01-a709-34e65c35f657"

--- a/Project.toml
+++ b/Project.toml
@@ -32,10 +32,11 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "Makie", "Random", "StableRNGs"]
+test = ["Test", "Aqua", "ForwardDiff", "Makie", "Random", "StableRNGs"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ DomainSetsRandomExt = "Random"
 [compat]
 Aqua = "0.8"
 CompositeTypes = "0.1.4"
+ForwardDiff = "1"
 FunctionMaps = "0.1.2"
 IntervalSets = "0.7.4"
 LinearAlgebra = "1"

--- a/src/domains/ball.jl
+++ b/src/domains/ball.jl
@@ -134,8 +134,8 @@ UnitBall{T,C}(dim::Int) where {T,C} = DynamicUnitBall{T,C}(dim)
 const ClosedUnitBall{T} = UnitBall{T,:closed}
 const OpenUnitBall{T} = UnitBall{T,:open}
 
-indomain(x, d::OpenUnitBall) = norm(x) < 1
-indomain(x, d::ClosedUnitBall) = norm(x) <= 1
+indomain(x, d::OpenUnitBall) = LinearAlgebra.norm_sqr(x) < 1
+indomain(x, d::ClosedUnitBall) = LinearAlgebra.norm_sqr(x) <= 1
 approx_indomain(x, d::OpenUnitBall, tolerance) = norm(x) < 1+tolerance
 approx_indomain(x, d::ClosedUnitBall, tolerance) = norm(x) <= 1+tolerance
 

--- a/test/test_domain_ball.jl
+++ b/test/test_domain_ball.jl
@@ -1,3 +1,5 @@
+using ForwardDiff, Test
+
 function test_balls()
     # Test UnitBall constructor
     @test UnitBall(2) isa VectorUnitBall{Float64}
@@ -393,4 +395,8 @@ function test_spheres()
     @test domain(p3) === UnitSphere()
     @test p3 ∈ UnitSphere()
     @test approx_in(DomainSets.point(p3), UnitSphere())
+
+    @testset "support in at origin with autodiff" begin
+        @test [ForwardDiff.Dual(0.,1.), ForwardDiff.Dual(0.,1.)] in UnitDisk()
+    end
 end

--- a/test/test_specific_domains.jl
+++ b/test/test_specific_domains.jl
@@ -707,10 +707,6 @@ end
     test_intervals()
 end
 
-@testset "balls" begin
-    test_balls()
-end
-
 @testset "simplex" begin
     test_simplex()
 end


### PR DESCRIPTION
norms with ForwardDiff's `Dual` are flaky:
```julia
julia> norm([Dual(0.0, (1.0,0.0)), Dual(0.0,(0.0,1.0))])
Dual{Nothing}(NaN,NaN,NaN)
```
This works around this issue.